### PR TITLE
Adding a second UIWindow to display the UIAlertController.

### DIFF
--- a/Sample App/Sample App/AppDelegate.swift
+++ b/Sample App/Sample App/AppDelegate.swift
@@ -30,9 +30,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Required
         siren.appID = "376771144" // For this example, we're using the iTunes Connect App (https://itunes.apple.com/us/app/itunes-connect/id376771144?mt=8)
         
-        // Required
-        siren.presentingViewController = window?.rootViewController
-        
         // Optional
         siren.delegate = self
         


### PR DESCRIPTION
*Problem:*
With UIAlertView we could call `show()` from the AppDelegate and have the UIAlertView implementation find the visible view controller and add the view as a subview. This no longer works with the new iOS 8 UIAlertController because it's a subclass of UIViewController (instead of UIView) and has to be presented just like any other view controller. Calling `presentViewController(...)` on the UIWindow's `rootViewController` will not work if the `rootViewController` is not visible when the app becomes active. We need a way to display the UIAlertController without calculating (or passing a reference to) the visible view controller.

*Solution:*
By using a second UIWindow we can ensure that its rootViewController is always the visible view controller. If we set the `windowLevel` of the second UIWindow to be `UIWindowLevelAlert + 1` we ensure that the window will always appear above any other views and view controllers in the app. Lastly, we need to create a strong reference to the second window via an associated object. If we do not do this, the window will be released before it's displayed.