### PR TITLE
Exposed currentAppStoreVersion

### DIFF
--- a/Siren.podspec
+++ b/Siren.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Siren"
-  s.version      = "0.6.6"
+  s.version      = "0.6.7"
   s.summary      = "Notify users when a new version of your iOS app is available, and prompt them with the App Store link.."
 
   s.description  = <<-DESC

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -221,7 +221,7 @@ public class Siren: NSObject {
     public var alertControllerTintColor: UIColor?
 
     /**
-     The current version of your app that is available to download on the App Store
+     The current version of your app that is available for download on the App Store
      */
     public private(set) var currentAppStoreVersion: String?
 

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -219,10 +219,14 @@ public class Siren: NSObject {
         Overrides the tint color for UIAlertController.
     */
     public var alertControllerTintColor: UIColor?
-    
+
+    /**
+     The current version of your app that is available to download on the App Store
+     */
+    public private(set) var currentAppStoreVersion: String?
+
     // Private
     private var lastVersionCheckPerformedOnDate: NSDate?
-    private var currentAppStoreVersion: String?
     private var updaterWindow: UIWindow?
     
     // MARK: Initialization


### PR DESCRIPTION
Originally, I was going to refactor the `sirenDidDetectNewVersionWithoutAlert(_:)` delegate method. However, it was easier to publicly expose the `currentAppStoreVersion` variable. 

So, to solve your problem @vicsonic, do the following:

```swift
func sirenDidDetectNewVersionWithoutAlert(message: String) {
    print("Message", message)
    print("App Store Version", Siren.sharedInstance().currentAppStoreVersion)
    print("App Name", Siren.sharedInstance().appName)
}
```
