### PR TITLE
Allow bundleID instead of AppID

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ func application(application: UIApplication, didFinishLaunchingWithOptions launc
 	// Siren is a singleton
 	let siren = Siren.sharedInstance
 
-	// Required: Your app's iTunes App Store ID
+	// Required: Either your app's iTunes App Store ID or the app's bundle identifier
 	siren.appID = <#Your_App_ID#>
+	// Or:
+	siren.bundleID = <#Your_Bundle_ID#>
 
 	// Optional: Defaults to .Option
 	siren.alertType = <#SirenAlertType_Enum_Value#>

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -11,13 +11,24 @@ import UIKit
 
 // MARK: - SirenDelegate Protocol
 
-@objc public protocol SirenDelegate {
-    optional func sirenDidShowUpdateDialog()                            // User presented with update dialog
-    optional func sirenUserDidLaunchAppStore()                          // User did click on button that launched App Store.app
-    optional func sirenUserDidSkipVersion()                             // User did click on button that skips version update
-    optional func sirenUserDidCancel()                                  // User did click on button that cancels update dialog
-    optional func sirenDidFailVersionCheck(error: NSError)              // Siren failed to perform version check (may return system-level error)
-    optional func sirenDidDetectNewVersionWithoutAlert(message: String) // Siren performed version check and did not display alert
+public protocol SirenDelegate: class {
+    func sirenDidShowUpdateDialog(alertType: SirenAlertType)   // User presented with update dialog
+    func sirenUserDidLaunchAppStore()                          // User did click on button that launched App Store.app
+    func sirenUserDidSkipVersion()                             // User did click on button that skips version update
+    func sirenUserDidCancel()                                  // User did click on button that cancels update dialog
+    func sirenDidFailVersionCheck(error: NSError)              // Siren failed to perform version check (may return system-level error)
+    func sirenDidDetectNewVersionWithoutAlert(message: String) // Siren performed version check and did not display alert
+}
+
+
+// Empty implementation in an extension on SirenDelegate to allow for optional implemenation of its methods
+extension SirenDelegate {
+    func sirenDidShowUpdateDialog(alertType: SirenAlertType) {}
+    func sirenUserDidLaunchAppStore() {}
+    func sirenUserDidSkipVersion() {}
+    func sirenUserDidCancel() {}
+    func sirenDidFailVersionCheck(error: NSError) {}
+    func sirenDidDetectNewVersionWithoutAlert(message: String) {}
 }
 
 
@@ -151,7 +162,7 @@ public final class Siren: NSObject {
         The SirenDelegate variable, which should be set if you'd like to be notified:
     
             - When a user views or interacts with the alert
-                - sirenDidShowUpdateDialog()
+                - sirenDidShowUpdateDialog(alertType: SirenAlertType)
                 - sirenUserDidLaunchAppStore()
                 - sirenUserDidSkipVersion()     
                 - sirenUserDidCancel()
@@ -453,12 +464,12 @@ private extension Siren {
             alertController.addAction(updateAlertAction())
             alertController.addAction(skipAlertAction())
         case .None:
-            delegate?.sirenDidDetectNewVersionWithoutAlert?(newVersionMessage)
+            delegate?.sirenDidDetectNewVersionWithoutAlert(newVersionMessage)
         }
         
         if alertType != .None {
             alertController.show()
-            delegate?.sirenDidShowUpdateDialog?()
+            delegate?.sirenDidShowUpdateDialog(alertType)
         }
     }
     
@@ -467,7 +478,7 @@ private extension Siren {
         let action = UIAlertAction(title: title, style: .Default) { (alert: UIAlertAction) in
             self.hideWindow()
             self.launchAppStore()
-            self.delegate?.sirenUserDidLaunchAppStore?()
+            self.delegate?.sirenUserDidLaunchAppStore()
             return
         }
         
@@ -478,7 +489,7 @@ private extension Siren {
         let title = localizedNextTimeButtonTitle()
         let action = UIAlertAction(title: title, style: .Default) { (alert: UIAlertAction) in
             self.hideWindow()
-            self.delegate?.sirenUserDidCancel?()
+            self.delegate?.sirenUserDidCancel()
             return
         }
         
@@ -493,7 +504,7 @@ private extension Siren {
                 NSUserDefaults.standardUserDefaults().synchronize()
             }
             self.hideWindow()
-            self.delegate?.sirenUserDidSkipVersion?()
+            self.delegate?.sirenUserDidSkipVersion()
             return
         }
         
@@ -721,7 +732,7 @@ private extension Siren {
 
         let error = NSError(domain: SirenErrorDomain, code: code.rawValue, userInfo: userInfo)
 
-        delegate?.sirenDidFailVersionCheck?(error)
+        delegate?.sirenDidFailVersionCheck(error)
 
         printMessage(error.localizedDescription)
     }

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -96,6 +96,7 @@ public enum SirenLanguageType: String {
  */
 private enum SirenErrorCode: Int {
     case MalformedURL = 1000
+    case RecentlyCheckedAlready
     case NoUpdateAvailable
     case AppStoreDataRetrievalFailure
     case AppStoreJSONParsingFailure
@@ -298,7 +299,7 @@ public final class Siren: NSObject {
             if daysSinceLastVersionCheckDate(lastVersionCheckPerformedOnDate) >= checkType.rawValue {
                 performVersionCheck()
             } else {
-                postError(.NoUpdateAvailable, underlyingError: nil)
+                postError(.RecentlyCheckedAlready, underlyingError: nil)
             }
         }
     }
@@ -666,6 +667,8 @@ private extension Siren {
         switch code {
         case .MalformedURL:
             description = "The iTunes URL is malformed. Please leave an issue on http://github.com/ArtSabintsev/Siren with as many details as possible."
+        case .RecentlyCheckedAlready:
+            description = "Not checking the version, because it already checked recently."
         case .NoUpdateAvailable:
             description = "No new update available."
         case .AppStoreDataRetrievalFailure:
@@ -673,9 +676,9 @@ private extension Siren {
         case .AppStoreJSONParsingFailure:
             description = "Error parsing App Store JSON data."
         case .AppStoreVersionNumberFailure:
-            description = "Error retrieving App Store verson number as there was no data returned."
+            description = "Error retrieving App Store version number as there was no data returned."
         case .AppStoreVersionArrayFailure:
-            description = "Error retrieving App Store verson number as results[0] does not contain a 'version' key."
+            description = "Error retrieving App Store version number as results[0] does not contain a 'version' key."
         }
 
         var userInfo: [String: AnyObject] = [NSLocalizedDescriptionKey: description]


### PR DESCRIPTION
An app's **bundleID** can be used, just as the **appID** to get App Store information about it.

It is useful to also have this feature in Siren, because it will be easier for the developer to get the bundleIdentifier instead of the appID (especially when the app hasn't been approved and released yet). 