### PR TITLE
Allow (optional) bundleID instead of (required) AppID

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ func application(application: UIApplication, didFinishLaunchingWithOptions launc
 	// Siren is a singleton
 	let siren = Siren.sharedInstance
 
-	// Required: Your app's iTunes App Store ID
+	// Required: Either your app's iTunes App Store ID or the app's bundle identifier
 	siren.appID = <#Your_App_ID#>
+	// Or:
+	siren.bundleID = <#Your_Bundle_ID#>
 
 	// Optional: Defaults to .Option
 	siren.alertType = <#SirenAlertType_Enum_Value#>

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -96,6 +96,7 @@ public enum SirenLanguageType: String {
  */
 private enum SirenErrorCode: Int {
     case MalformedURL = 1000
+    case RecentlyCheckedAlready
     case NoUpdateAvailable
     case AppStoreDataRetrievalFailure
     case AppStoreJSONParsingFailure
@@ -298,7 +299,7 @@ public final class Siren: NSObject {
             if daysSinceLastVersionCheckDate(lastVersionCheckPerformedOnDate) >= checkType.rawValue {
                 performVersionCheck()
             } else {
-                postError(.NoUpdateAvailable, underlyingError: nil)
+                postError(.RecentlyCheckedAlready, underlyingError: nil)
             }
         }
     }
@@ -666,6 +667,8 @@ private extension Siren {
         switch code {
         case .MalformedURL:
             description = "The iTunes URL is malformed. Please leave an issue on http://github.com/ArtSabintsev/Siren with as many details as possible."
+        case .RecentlyCheckedAlready:
+            description = "Not checking the version, because it already checked recently."
         case .NoUpdateAvailable:
             description = "No new update available."
         case .AppStoreDataRetrievalFailure:
@@ -673,9 +676,9 @@ private extension Siren {
         case .AppStoreJSONParsingFailure:
             description = "Error parsing App Store JSON data."
         case .AppStoreVersionNumberFailure:
-            description = "Error retrieving App Store verson number as there was no data returned."
+            description = "Error retrieving App Store version number as there was no data returned."
         case .AppStoreVersionArrayFailure:
-            description = "Error retrieving App Store verson number as results[0] does not contain a 'version' key."
+            description = "Error retrieving App Store version number as results[0] does not contain a 'version' key."
         }
 
         var userInfo: [String: AnyObject] = [NSLocalizedDescriptionKey: description]


### PR DESCRIPTION
An app's **bundleID** can be used, just as the **appID** to get App Store information about it.

It is useful to also have this feature in Siren, because it will be easier for the developer to get the bundleIdentifier instead of the appID (especially when the app hasn't been approved and released yet).

One more thing to mention: I chose for the **bundleID** to be a variable which needs to be set before a version check is performed. Alternatively, we could get the bundleID automatically from the `mainBundle`, just as is done with the `appName`. However I like to have more control over which bundleID is used, as it might differ between AppStore version and debug version.

(Also I added a specialized error for when it won't check the version, because the last version check was too recent)