### PR TITLE
Change SirenDelegate from @objc protocol to swift protocol

### DIFF
--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -22,7 +22,7 @@ public protocol SirenDelegate: class {
 
 
 // Empty implementation in an extension on SirenDelegate to allow for optional implemenation of its methods
-extension SirenDelegate {
+public extension SirenDelegate {
     func sirenDidShowUpdateDialog(alertType: SirenAlertType) {}
     func sirenUserDidLaunchAppStore() {}
     func sirenUserDidSkipVersion() {}

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -11,13 +11,24 @@ import UIKit
 
 // MARK: - SirenDelegate Protocol
 
-@objc public protocol SirenDelegate {
-    optional func sirenDidShowUpdateDialog()                            // User presented with update dialog
-    optional func sirenUserDidLaunchAppStore()                          // User did click on button that launched App Store.app
-    optional func sirenUserDidSkipVersion()                             // User did click on button that skips version update
-    optional func sirenUserDidCancel()                                  // User did click on button that cancels update dialog
-    optional func sirenDidFailVersionCheck(error: NSError)              // Siren failed to perform version check (may return system-level error)
-    optional func sirenDidDetectNewVersionWithoutAlert(message: String) // Siren performed version check and did not display alert
+public protocol SirenDelegate: class {
+    func sirenDidShowUpdateDialog(alertType: SirenAlertType)   // User presented with update dialog
+    func sirenUserDidLaunchAppStore()                          // User did click on button that launched App Store.app
+    func sirenUserDidSkipVersion()                             // User did click on button that skips version update
+    func sirenUserDidCancel()                                  // User did click on button that cancels update dialog
+    func sirenDidFailVersionCheck(error: NSError)              // Siren failed to perform version check (may return system-level error)
+    func sirenDidDetectNewVersionWithoutAlert(message: String) // Siren performed version check and did not display alert
+}
+
+
+// Empty implementation in an extension on SirenDelegate to allow for optional implemenation of its methods
+extension SirenDelegate {
+    func sirenDidShowUpdateDialog(alertType: SirenAlertType) {}
+    func sirenUserDidLaunchAppStore() {}
+    func sirenUserDidSkipVersion() {}
+    func sirenUserDidCancel() {}
+    func sirenDidFailVersionCheck(error: NSError) {}
+    func sirenDidDetectNewVersionWithoutAlert(message: String) {}
 }
 
 
@@ -148,7 +159,7 @@ public final class Siren: NSObject {
         The SirenDelegate variable, which should be set if you'd like to be notified:
     
             - When a user views or interacts with the alert
-                - sirenDidShowUpdateDialog()
+                - sirenDidShowUpdateDialog(alertType: SirenAlertType)
                 - sirenUserDidLaunchAppStore()
                 - sirenUserDidSkipVersion()     
                 - sirenUserDidCancel()
@@ -430,12 +441,12 @@ private extension Siren {
             alertController.addAction(updateAlertAction())
             alertController.addAction(skipAlertAction())
         case .None:
-            delegate?.sirenDidDetectNewVersionWithoutAlert?(newVersionMessage)
+            delegate?.sirenDidDetectNewVersionWithoutAlert(newVersionMessage)
         }
         
         if alertType != .None {
             alertController.show()
-            delegate?.sirenDidShowUpdateDialog?()
+            delegate?.sirenDidShowUpdateDialog(alertType)
         }
     }
     
@@ -444,7 +455,7 @@ private extension Siren {
         let action = UIAlertAction(title: title, style: .Default) { (alert: UIAlertAction) in
             self.hideWindow()
             self.launchAppStore()
-            self.delegate?.sirenUserDidLaunchAppStore?()
+            self.delegate?.sirenUserDidLaunchAppStore()
             return
         }
         
@@ -455,7 +466,7 @@ private extension Siren {
         let title = localizedNextTimeButtonTitle()
         let action = UIAlertAction(title: title, style: .Default) { (alert: UIAlertAction) in
             self.hideWindow()
-            self.delegate?.sirenUserDidCancel?()
+            self.delegate?.sirenUserDidCancel()
             return
         }
         
@@ -470,7 +481,7 @@ private extension Siren {
                 NSUserDefaults.standardUserDefaults().synchronize()
             }
             self.hideWindow()
-            self.delegate?.sirenUserDidSkipVersion?()
+            self.delegate?.sirenUserDidSkipVersion()
             return
         }
         
@@ -686,7 +697,7 @@ private extension Siren {
 
         let error = NSError(domain: SirenErrorDomain, code: code.rawValue, userInfo: userInfo)
 
-        delegate?.sirenDidFailVersionCheck?(error)
+        delegate?.sirenDidFailVersionCheck(error)
 
         printMessage(error.localizedDescription)
     }


### PR DESCRIPTION
I would like Siren's delegate to receive the **alertType** (as `SirenAlertType`) with the delegate method `sirenDidShowUpdateDialog()`, like this:

```swift
func sirenDidShowUpdateDialog(alertType: SirenAlertType) { ... }
```

And in order to be able to send an enum parameter to the `SirenDelegate` protocol, the protocol needs to be converted from a **@objc** protocol to a **swift** protocol.

And because it's not possible to use the `optional` keyword with non-@objc protocols, I also added empty implementations of the protocol methods in a _protocol extension_.