### PR TITLE
Alternative App Store support.

### DIFF
--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -252,6 +252,12 @@ public final class Siren: NSObject {
         Custom routine to obtain current available app version (instead of app store)
     */
     public var getVersion: (() -> String)? = nil
+    
+    /**
+        Custom update routine
+    */
+    public var performUpdate: (() -> Void)? = nil
+    
 
     /**
      The current version of your app that is available for download on the App Store
@@ -631,6 +637,13 @@ private extension Siren {
     }
 
     func launchAppStore() {
+        if let performUpdate = performUpdate {
+            dispatch_async(dispatch_get_main_queue()) {
+                performUpdate()
+            }
+            return
+        }
+        
         guard let appID = appID else {
             return
         }

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -247,6 +247,11 @@ public final class Siren: NSObject {
         Overrides the tint color for UIAlertController.
     */
     public var alertControllerTintColor: UIColor?
+    
+    /**
+        Custom routine to obtain current available app version (instead of app store)
+    */
+    public var getVersion: (() -> String)? = nil
 
     /**
      The current version of your app that is available for download on the App Store
@@ -296,6 +301,12 @@ public final class Siren: NSObject {
     }
     
     private func performVersionCheck() {
+        // check if custom version check
+        if let getVersion = getVersion {
+            currentAppStoreVersion = getVersion()
+            compareVersion()
+            return
+        }
         
         // Create Request
         do {
@@ -377,16 +388,21 @@ public final class Siren: NSObject {
                 return
             }
             
-            if isAppStoreVersionNewer() {
-                showAlertIfCurrentAppStoreVersionNotSkipped()
-            } else {
-                postError(.NoUpdateAvailable, underlyingError: nil)
-            }
-           
+            compareVersion()
         } else { // lookupResults does not contain any data as the returned array is empty
             postError(.AppStoreDataRetrievalFailure, underlyingError: nil)
         }
 
+    }
+    
+    private func compareVersion() {
+        
+        if isAppStoreVersionNewer() {
+            showAlertIfCurrentAppStoreVersionNotSkipped()
+        } else {
+            postError(.NoUpdateAvailable, underlyingError: nil)
+        }
+        
     }
 }
 


### PR DESCRIPTION
General idea is to support TestFlight or others mean of App distribution.

Add ability to have a custom routine (closure) to obtain current available app version instead of the app store and custom routine to update app.