### PR TITLE
Bugfix/url components

### DIFF
--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -530,14 +530,14 @@ private extension Siren {
         }
 
         components.queryItems = items
+        let url = components.URL
+        let urlString = url.absoluteString
 
-        guard let url = components.URL,
-            urlString = url.absoluteString
-            where !urlString.isEmpty else { // https://openradar.appspot.com/25382891
-                throw SirenErrorType.MalformedURL
+        if !urlString.isEmpty {
+            return url
+        } else {
+            throw SirenErrorType.MalformedURL
         }
-
-        return url
     }
 
     func daysSinceLastVersionCheckDate(lastVersionCheckPerformedOnDate: NSDate) -> Int {

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -530,10 +530,8 @@ private extension Siren {
         }
 
         components.queryItems = items
-        let url = components.URL
-        let urlString = url.absoluteString
 
-        if !urlString.isEmpty {
+        if let url = components.URL where !url.absoluteString.isEmpty {
             return url
         } else {
             throw SirenErrorType.MalformedURL


### PR DESCRIPTION
Hey Arthur, Paul (Prolific Interactive) suggested I make a PR for you to look at when you have a chance. 

We weren't able to compile with the current `swift2.3` branch as the compiler would always fail on the `guard let url = components.URL` statement. 

This PR simply refactors that guard statement to work around the compiler.

If there is a way to compile with the current code, please let me know! 