### PR TITLE
Use CFBundleDisplayName when available, and keep application status bar style

### DIFF
--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -224,7 +224,7 @@ public final class Siren: NSObject {
     
         By default, it's set to the name of the app that's stored in your plist.
     */
-    public lazy var appName: String = (Bundle.main.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String) ?? ""
+    public lazy var appName: String = (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? (Bundle.main.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String) ?? ""
     
     /**
         The region or country of an App Store in which your app is available.

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -647,13 +647,17 @@ fileprivate extension UIAlertController {
 
     func show() {
         let window = UIWindow(frame: UIScreen.main.bounds)
-        window.rootViewController = UIViewController()
+        window.rootViewController = ViewController()
         window.windowLevel = UIWindowLevelAlert + 1
         
         Siren.sharedInstance.updaterWindow = window
         
         window.makeKeyAndVisible()
         window.rootViewController!.present(self, animated: true, completion: nil)
+    }
+
+    class ViewController: UIViewController {
+        override var preferredStatusBarStyle: UIStatusBarStyle { return UIApplication.shared.statusBarStyle }
     }
 
 }

--- a/Siren/Siren.swift
+++ b/Siren/Siren.swift
@@ -224,8 +224,8 @@ public final class Siren: NSObject {
     
         By default, it's set to the name of the app that's stored in your plist.
     */
-    public lazy var appName: String = (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? (Bundle.main.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String) ?? ""
-    
+    public lazy var appName: String = Bundle.main.bestMatchingAppName()
+
     /**
         The region or country of an App Store in which your app is available.
         
@@ -691,6 +691,10 @@ fileprivate extension Bundle {
         }
         
         return Bundle(path: path)!.localizedString(forKey: stringKey, value: stringKey, table: table)
+    }
+
+    func bestMatchingAppName() -> String {
+        return (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? (Bundle.main.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String) ?? ""
     }
 
 }


### PR DESCRIPTION
- Uses the `CFBundleDisplayName` of the app for the displayed app name before falling back to `CFBundleName`.
- Keeps the current app status bar style. Before always the default was used.