### PR TITLE
2.0.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,4 +13,4 @@ file_length:
   - 1000
 
 line_length:
-  - 160
+  - 200

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
   - cyclomatic_complexity
   - file_length
   - line_length
+  - unused_optional_binding
   - variable_name
 
 reporter: "xcode"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,11 +1,16 @@
+reporter: "xcode"
+
 included:
   - ../Sources/
 
 disabled_rules:
   - cyclomatic_complexity
-  - file_length
-  - line_length
   - unused_optional_binding
   - variable_name
 
-reporter: "xcode"
+# Specialized Rules
+file_length:
+  - 1000
+
+line_length:
+  - 160

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 ## Table of Contents
 - [About](https://github.com/ArtSabintsev/Siren#about)
-- [README Translations](https://github.com/ArtSabintsev/Siren#readme-translations)
 - [Features](https://github.com/ArtSabintsev/Siren#features)
 - [Screenshots](https://github.com/ArtSabintsev/Siren#screenshots)
 - [Installation Instructions](https://github.com/ArtSabintsev/Siren#installation-instructions)
@@ -33,20 +32,19 @@ If a new version is available, an alert can be presented to the user informing t
 	- Siren also supports two-number versioning (e.g., 1.0) and four-number versioning (e.g., 1.0.0.0)
 - Siren is actively maintained by [**Arthur Sabintsev**](http://github.com/ArtSabintsev) and [**Aaron Brager**](http://twitter.com/getaaron)
 
----
-## README Translations
+### README Translations
 - [**简体中文**](README.zh_CN.md) (by [**Daniel Hu**](http://www.jianshu.com/u/d8bbc4831623))
 
 ## Features
 - [x] CocoaPods Support
 - [x] Carthage Support
 - [x] Swift Package Manager Support
-- [x] Localized for 30+ languages (See **Localization**)
-- [x] Pre-Update Device Compatibility Check (See **Device Compatibility**)
-- [x] Three types of alerts (see **Screenshots**)
-- [x] Optional delegate methods (see **Optional Delegate**)
+- [x] Localized for 30+ languages (see [Localization](https://github.com/ArtSabintsev/Siren#localization))
+- [x] Pre-Update Device Compatibility Check (see [Device Compatibility](https://github.com/ArtSabintsev/Siren#device-compatibility)
+- [x] Three types of alerts (see [Screenshots](https://github.com/ArtSabintsev/Siren#screenshots))
+- [x] Optional delegate methods (see [Delegates (Optional)](https://github.com/ArtSabintsev/Siren#optional-delegate-and-delegate-methods)
 - [x] Unit Tests
-- [x] Documentation can be found at http://sabintsev.com/Siren
+- [x] Documentation can be found at http://sabintsev.com/Siren.
 
 ## Screenshots
 - The **left picture** forces the user to update the app.
@@ -87,7 +85,7 @@ For Swift 2.3 support:
 ``` swift
 github "ArtSabintsev/Siren" "swift2.3"
 ```
-\
+
 ### Swift Package Manager
 ```swift
 .Package(url: "https://github.com/ArtSabintsev/Siren.git", majorVersion: 1)
@@ -95,22 +93,26 @@ github "ArtSabintsev/Siren" "swift2.3"
 
 ## Example Code
 
-Here's some commented sample code. Adapt this to meet your app's needs. For a full list of optional settings/preferences, please refer to https://github.com/ArtSabintsev/Siren/blob/master/Sample%20App/Sample%20App/AppDelegate.swift in the Sample Project.
+Below is some commented sample code. Adapt this to meet your app's needs.
+
+For a full list of optional settings/preferences, please refer to https://github.com/ArtSabintsev/Siren/blob/master/SirenExample/SirenExample/AppDelegate.swift in the Sample Project.
 
 ```Swift
 func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
 	/* Siren code should go below window?.makeKeyAndVisible() */
 
-	// Siren is a singleton
-	let siren = Siren.shared
+	  // Siren is a singleton
+	  let siren = Siren.shared
 
-	// Optional: Defaults to .Option
-	siren.alertType = <#SirenAlertType_Enum_Value#>
+	  // Optional - Defaults to .Option
+	  siren.alertType = <#SirenAlertType_Enum_Value#>
 
-	/*
-	    Replace .Immediately with .Daily or .Weekly to specify a maximum daily or weekly frequency for version
-	    checks.
-	*/
+	  // Optional - Set this variable if you would only like to show an alert if your app has been available on the store for a few days.
+	  // This value defaults to 1 to avoid a rare condition on Apple's end
+	  // The number 3 is used as an example.
+	  siren.showAlertAfterCurrentVersionHasBeenReleasedForDays = 3
+
+	  // Replace .Immediately with .Daily or .Weekly to specify a maximum daily or weekly frequency for version checks.
     siren.checkVersion(checkType: .immediately)
 
     return true

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ func application(application: UIApplication, didFinishLaunchingWithOptions launc
 	  // Siren is a singleton
 	  let siren = Siren.shared
 
-	  // Optional - Defaults to .Option
+	  // Optional: Defaults to .Option
 	  siren.alertType = <#SirenAlertType_Enum_Value#>
 
-	  // Optional - Set this variable if you would only like to show an alert if your app has been available on the store for a few days.
-	  // This value defaults to 1 to avoid a rare condition on Apple's end
-	  // The number 3 is used as an example.
+	  // Optional: Set this variable if you would only like to show an alert if your app has been available on the store for a few days.
+	  // This default value is set to 1 to avoid this issue: https://github.com/ArtSabintsev/Siren#words-of-caution
+	  // To show the update immediately after Apple has updated their JSON, set this value to 0. Not recommended due to aforementioned reason in https://github.com/ArtSabintsev/Siren#words-of-caution.
 	  siren.showAlertAfterCurrentVersionHasBeenReleasedForDays = 3
 
 	  // Replace .Immediately with .Daily or .Weekly to specify a maximum daily or weekly frequency for version checks.
@@ -246,7 +246,7 @@ The App Store reviewer will **not** see the alert. The version in the App Store 
 ## Words of Caution
 Occassionally, the iTunes JSON will update faster than the App Store CDN, meaning the JSON may state that the new verison of the app has been release, while no new binary is made available for download via the App Store. It is for this reason, I caution developers to not use the `Force` option unless you are controlling the `Force` option with a remote configuration file (e.g., enabling Siren remotely only after you have guaranteed that the app has propogated to the App Store).
 
-Also, on even rarer situations, the iTunes JSON may fluctuate between multiple versions of your app shortly after pushing out a new version. This is extremely rare, and has only been reported once in the five years of that Siren and Harpy have been around.
+Also, in even rarer situations, the iTunes JSON may fluctuate between multiple versions of your app shortly after pushing out a new version. This is extremely rare, and has only been reported once in the five years that Siren and Harpy have been around.
 
 ## Ports
 - **Objective-C (iOS)**

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ github "ArtSabintsev/Siren" "swift2.3"
 
 ### Swift Package Manager
 ```swift
-.Package(url: "https://github.com/ArtSabintsev/Siren.git", majorVersion: 1)
+.Package(url: "https://github.com/ArtSabintsev/Siren.git", majorVersion: 2)
 ```
 
 ## Example Code

--- a/Siren.podspec
+++ b/Siren.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Siren"
-  s.version      = "1.2.5"
+  s.version      = "2.0.0"
   s.summary      = "Notify users when a new version of your iOS app is available, and prompt them with the App Store link.."
 
   s.description  = <<-DESC

--- a/SirenExample/SirenExample.xcodeproj/project.pbxproj
+++ b/SirenExample/SirenExample.xcodeproj/project.pbxproj
@@ -128,14 +128,22 @@
 			isa = PBXGroup;
 			children = (
 				8EE6C7411E6A0AA500DBE454 /* AppDelegate.swift */,
+				8E528A331E98AED300B643C4 /* Supporting Files */,
+			);
+			name = SirenExample;
+			path = "Sample App";
+			sourceTree = "<group>";
+		};
+		8E528A331E98AED300B643C4 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
 				8EE6C7421E6A0AA500DBE454 /* ViewController.swift */,
 				8EBDF8211E6A0C41006C87B4 /* LaunchScreen.xib */,
 				8EBDF8231E6A0C41006C87B4 /* Main.storyboard */,
 				8EE6C7461E6A0AB800DBE454 /* Images.xcassets */,
 				8EE6C7471E6A0AB800DBE454 /* Info.plist */,
 			);
-			name = SirenExample;
-			path = "Sample App";
+			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 		8EC391781A58B465001C121E = {

--- a/SirenExample/SirenExample.xcodeproj/project.pbxproj
+++ b/SirenExample/SirenExample.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		8E1635A91E6A0B9C0060CE27 /* SirenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE6C74C1E6A0AE100DBE454 /* SirenTests.swift */; };
 		8E43D6231E8223EE00ECFFC8 /* SirenDateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */; };
 		8E528A301E989A7A00B643C4 /* SirenDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */; };
+		8E528A321E989E0A00B643C4 /* SirenTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E528A311E989E0A00B643C4 /* SirenTestHelper.swift */; };
 		8E9C238B1E7CDB42000ED3DA /* SirenBundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */; };
 		8E9C238D1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C238C1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift */; };
 		8E9C238F1E7CDDE7000ED3DA /* SirenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C238E1E7CDDE7000ED3DA /* SirenViewController.swift */; };
@@ -65,6 +66,7 @@
 		8E3A6C041D07CB6F00A8B7CF /* SirenExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SirenExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenDateExtension.swift; path = ../../Sources/SirenDateExtension.swift; sourceTree = "<group>"; };
 		8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenDelegate.swift; path = ../../Sources/SirenDelegate.swift; sourceTree = "<group>"; };
+		8E528A311E989E0A00B643C4 /* SirenTestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenTestHelper.swift; path = ../../Sources/SirenTestHelper.swift; sourceTree = "<group>"; };
 		8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenBundleExtension.swift; path = ../../Sources/SirenBundleExtension.swift; sourceTree = "<group>"; };
 		8E9C238C1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenUIAlertControllerExtension.swift; path = ../../Sources/SirenUIAlertControllerExtension.swift; sourceTree = "<group>"; };
 		8E9C238E1E7CDDE7000ED3DA /* SirenViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenViewController.swift; path = ../../Sources/SirenViewController.swift; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 				8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */,
 				8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */,
 				8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */,
+				8E528A311E989E0A00B643C4 /* SirenTestHelper.swift */,
 				8E9C238C1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift */,
 				8E9C238E1E7CDDE7000ED3DA /* SirenViewController.swift */,
 				55EC36491E6BB98A00726F13 /* Siren.h */,
@@ -333,6 +336,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8E528A321E989E0A00B643C4 /* SirenTestHelper.swift in Sources */,
 				8E9C238F1E7CDDE7000ED3DA /* SirenViewController.swift in Sources */,
 				55EC36611E6BB99B00726F13 /* Siren.swift in Sources */,
 				8E43D6231E8223EE00ECFFC8 /* SirenDateExtension.swift in Sources */,

--- a/SirenExample/SirenExample.xcodeproj/project.pbxproj
+++ b/SirenExample/SirenExample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		55EC36611E6BB99B00726F13 /* Siren.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC365F1E6BB99B00726F13 /* Siren.swift */; };
 		8E1635A91E6A0B9C0060CE27 /* SirenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE6C74C1E6A0AE100DBE454 /* SirenTests.swift */; };
 		8E43D6231E8223EE00ECFFC8 /* SirenDateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */; };
+		8E528A301E989A7A00B643C4 /* SirenDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */; };
 		8E9C238B1E7CDB42000ED3DA /* SirenBundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */; };
 		8E9C238D1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C238C1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift */; };
 		8E9C238F1E7CDDE7000ED3DA /* SirenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C238E1E7CDDE7000ED3DA /* SirenViewController.swift */; };
@@ -63,6 +64,7 @@
 		55EC365F1E6BB99B00726F13 /* Siren.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Siren.swift; path = ../../Sources/Siren.swift; sourceTree = "<group>"; };
 		8E3A6C041D07CB6F00A8B7CF /* SirenExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SirenExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenDateExtension.swift; path = ../../Sources/SirenDateExtension.swift; sourceTree = "<group>"; };
+		8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenDelegate.swift; path = ../../Sources/SirenDelegate.swift; sourceTree = "<group>"; };
 		8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenBundleExtension.swift; path = ../../Sources/SirenBundleExtension.swift; sourceTree = "<group>"; };
 		8E9C238C1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenUIAlertControllerExtension.swift; path = ../../Sources/SirenUIAlertControllerExtension.swift; sourceTree = "<group>"; };
 		8E9C238E1E7CDDE7000ED3DA /* SirenViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenViewController.swift; path = ../../Sources/SirenViewController.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 			children = (
 				55EC365E1E6BB99B00726F13 /* Siren.bundle */,
 				55EC365F1E6BB99B00726F13 /* Siren.swift */,
+				8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */,
 				8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */,
 				8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */,
 				8E9C238C1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift */,
@@ -334,6 +337,7 @@
 				55EC36611E6BB99B00726F13 /* Siren.swift in Sources */,
 				8E43D6231E8223EE00ECFFC8 /* SirenDateExtension.swift in Sources */,
 				8E9C238B1E7CDB42000ED3DA /* SirenBundleExtension.swift in Sources */,
+				8E528A301E989A7A00B643C4 /* SirenDelegate.swift in Sources */,
 				8E9C238D1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -49,10 +49,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Optional - Set this variable if your app is not available in the U.S. App Store. List of codes: https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Appendices/AppStoreTerritories.html
 //        siren.countryCode = ""
 
-        // Optional - Set this variable if you would only like to show an alert if your app has been available on the store for a few days. 
-        // This value defaults to 1.
-        // The number 5 is used as an example.
-//        siren.showAlertAfterCurrentVersionHasBeenReleasedForDays = 5
+        // Optional - Set this variable if you would only like to show an alert if your app has been available on the store for a few days.
+        // This value defaults to 1 to avoid this issue: https://github.com/ArtSabintsev/Siren#words-of-caution
+        // The number 3 is used as an example.
+//        siren.showAlertAfterCurrentVersionHasBeenReleasedForDays = 3
 
         // Required
         siren.checkVersion(checkType: .immediately)

--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -50,8 +50,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 //        siren.countryCode = ""
 
         // Optional - Set this variable if you would only like to show an alert if your app has been available on the store for a few days.
-        // This value defaults to 1 to avoid this issue: https://github.com/ArtSabintsev/Siren#words-of-caution
-        // The number 3 is used as an example.
+        // This default value is set to 1 to avoid this issue: https://github.com/ArtSabintsev/Siren#words-of-caution
+        // To show the update immediately after Apple has updated their JSON, set this value to 0. Not recommended due to aforementioned reason in https://github.com/ArtSabintsev/Siren#words-of-caution.
 //        siren.showAlertAfterCurrentVersionHasBeenReleasedForDays = 3
 
         // Required

--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -31,9 +31,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Optional
         siren.debugEnabled = true
 
-        // Optional
-        siren.appName = "Test App Name"
-        
+        // Optional - Change the name of your app. Useful if you have a long app name and want to display a shortened version in the update dialog (e.g., the UIAlertController).
+//        siren.appName = "Test App Name"
+
         // Optional - Defaults to .Option
 //        siren.alertType = .Option // or .Force, .Skip, .None
 
@@ -49,7 +49,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Optional - Set this variable if your app is not available in the U.S. App Store. List of codes: https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Appendices/AppStoreTerritories.html
 //        siren.countryCode = ""
 
-        // Optional - Set this variable if you would only like to show an alert if your app has been available on the store for a few days. The number 5 is used as an example.
+        // Optional - Set this variable if you would only like to show an alert if your app has been available on the store for a few days. 
+        // This value defaults to 1.
+        // The number 5 is used as an example.
 //        siren.showAlertAfterCurrentVersionHasBeenReleasedForDays = 5
 
         // Required

--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -69,7 +69,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate: SirenDelegate
 {
-    func sirenDidShowUpdateDialog(alertType: SirenAlertType) {
+    func sirenDidShowUpdateDialog(alertType: Siren.AlertType) {
         print(#function, alertType)
     }
     

--- a/SirenExample/SirenExampleTests/SirenTests.swift
+++ b/SirenExample/SirenExampleTests/SirenTests.swift
@@ -139,7 +139,7 @@ extension SirenTests {
 extension SirenTests {
 
     func testArabicLocalization() {
-        let language: SirenLanguageType = .Arabic
+        let language: Siren.LanguageType = .Arabic
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -156,7 +156,7 @@ extension SirenTests {
     }
 
     func testArmenianLocalization() {
-        let language: SirenLanguageType = .Armenian
+        let language: Siren.LanguageType = .Armenian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -173,7 +173,7 @@ extension SirenTests {
     }
 
     func testBasqueLocalization() {
-        let language: SirenLanguageType = .Basque
+        let language: Siren.LanguageType = .Basque
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -190,7 +190,7 @@ extension SirenTests {
     }
 
     func testChineseSimplifiedLocalization() {
-        let language: SirenLanguageType = .ChineseSimplified
+        let language: Siren.LanguageType = .ChineseSimplified
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -207,7 +207,7 @@ extension SirenTests {
     }
 
     func testChineseTraditionalLocalization() {
-        let language: SirenLanguageType = .ChineseTraditional
+        let language: Siren.LanguageType = .ChineseTraditional
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -224,7 +224,7 @@ extension SirenTests {
     }
 
     func testCroatianLocalization() {
-        let language: SirenLanguageType = .Croatian
+        let language: Siren.LanguageType = .Croatian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -241,7 +241,7 @@ extension SirenTests {
     }
 
     func testDanishLocalization() {
-        let language: SirenLanguageType = .Danish
+        let language: Siren.LanguageType = .Danish
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -258,7 +258,7 @@ extension SirenTests {
     }
 
     func testDutchLocalization() {
-        let language: SirenLanguageType = .Dutch
+        let language: Siren.LanguageType = .Dutch
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -275,7 +275,7 @@ extension SirenTests {
     }
 
     func testEstonianLocalization() {
-        let language: SirenLanguageType = .Estonian
+        let language: Siren.LanguageType = .Estonian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -292,7 +292,7 @@ extension SirenTests {
     }
 
     func testFinnishLocalization() {
-        let language: SirenLanguageType = .Finnish
+        let language: Siren.LanguageType = .Finnish
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -309,7 +309,7 @@ extension SirenTests {
     }
 
     func testFrenchLocalization() {
-        let language: SirenLanguageType = .French
+        let language: Siren.LanguageType = .French
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -326,7 +326,7 @@ extension SirenTests {
     }
 
     func testGermanLocalization() {
-        let language: SirenLanguageType = .German
+        let language: Siren.LanguageType = .German
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -343,7 +343,7 @@ extension SirenTests {
     }
     
     func testGreekLocalization() {
-        let language: SirenLanguageType = .Greek
+        let language: Siren.LanguageType = .Greek
         siren.forceLanguageLocalization = language
         
         // Update Available
@@ -360,7 +360,7 @@ extension SirenTests {
     }
 
     func testHebrewLocalization() {
-        let language: SirenLanguageType = .Hebrew
+        let language: Siren.LanguageType = .Hebrew
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -377,7 +377,7 @@ extension SirenTests {
     }
 
     func testHungarianLocalization() {
-        let language: SirenLanguageType = .Hungarian
+        let language: Siren.LanguageType = .Hungarian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -394,7 +394,7 @@ extension SirenTests {
     }
 
     func testIndonesianLocalization() {
-        let language: SirenLanguageType = .Indonesian
+        let language: Siren.LanguageType = .Indonesian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -411,7 +411,7 @@ extension SirenTests {
     }
 
     func testItalianLocalization() {
-        let language: SirenLanguageType = .Italian
+        let language: Siren.LanguageType = .Italian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -428,7 +428,7 @@ extension SirenTests {
     }
 
     func testJapaneseLocalization() {
-        let language: SirenLanguageType = .Japanese
+        let language: Siren.LanguageType = .Japanese
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -445,7 +445,7 @@ extension SirenTests {
     }
 
     func testKoreanLocalization() {
-        let language: SirenLanguageType = .Korean
+        let language: Siren.LanguageType = .Korean
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -462,7 +462,7 @@ extension SirenTests {
     }
 
     func testLatvianLocalization() {
-        let language: SirenLanguageType = .Latvian
+        let language: Siren.LanguageType = .Latvian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -479,7 +479,7 @@ extension SirenTests {
     }
 
     func testLithuanianLocalization() {
-        let language: SirenLanguageType = .Lithuanian
+        let language: Siren.LanguageType = .Lithuanian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -496,7 +496,7 @@ extension SirenTests {
     }
 
     func testMalayLocalization() {
-        let language: SirenLanguageType = .Malay
+        let language: Siren.LanguageType = .Malay
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -513,7 +513,7 @@ extension SirenTests {
     }
 
     func testNorwegianLocalization() {
-        let language: SirenLanguageType = .Norwegian
+        let language: Siren.LanguageType = .Norwegian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -530,7 +530,7 @@ extension SirenTests {
     }
 
     func testPolishLocalization() {
-        let language: SirenLanguageType = .Polish
+        let language: Siren.LanguageType = .Polish
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -547,7 +547,7 @@ extension SirenTests {
     }
 
     func testPortugueseBrazilLocalization() {
-        let language: SirenLanguageType = .PortugueseBrazil
+        let language: Siren.LanguageType = .PortugueseBrazil
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -564,7 +564,7 @@ extension SirenTests {
     }
 
     func testPortuguesePortugalLocalization() {
-        let language: SirenLanguageType = .PortuguesePortugal
+        let language: Siren.LanguageType = .PortuguesePortugal
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -581,7 +581,7 @@ extension SirenTests {
     }
 
     func testRussianLocalization() {
-        let language: SirenLanguageType = .Russian
+        let language: Siren.LanguageType = .Russian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -598,7 +598,7 @@ extension SirenTests {
     }
 
     func testSerbianCyrillicLocalization() {
-        let language: SirenLanguageType = .SerbianCyrillic
+        let language: Siren.LanguageType = .SerbianCyrillic
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -615,7 +615,7 @@ extension SirenTests {
     }
 
     func testSerbianLatinLocalization() {
-        let language: SirenLanguageType = .SerbianLatin
+        let language: Siren.LanguageType = .SerbianLatin
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -632,7 +632,7 @@ extension SirenTests {
     }
 
     func testSlovenianLocalization() {
-        let language: SirenLanguageType = .Slovenian
+        let language: Siren.LanguageType = .Slovenian
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -649,7 +649,7 @@ extension SirenTests {
     }
 
     func testSpanishLocalization() {
-        let language: SirenLanguageType = .Spanish
+        let language: Siren.LanguageType = .Spanish
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -666,7 +666,7 @@ extension SirenTests {
     }
 
     func testSwedishLocalization() {
-        let language: SirenLanguageType = .Swedish
+        let language: Siren.LanguageType = .Swedish
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -683,7 +683,7 @@ extension SirenTests {
     }
 
     func testThaiLocalization() {
-        let language: SirenLanguageType = .Thai
+        let language: Siren.LanguageType = .Thai
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -700,7 +700,7 @@ extension SirenTests {
     }
 
     func testTurkishLocalization() {
-        let language: SirenLanguageType = .Turkish
+        let language: Siren.LanguageType = .Turkish
         siren.forceLanguageLocalization = language
 
         // Update Available
@@ -717,7 +717,7 @@ extension SirenTests {
     }
     
     func testVietnameseLocalization() {
-        let language: SirenLanguageType = .Vietnamese
+        let language: Siren.LanguageType = .Vietnamese
         siren.forceLanguageLocalization = language
 
         // Update Available

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -185,7 +185,7 @@ private extension Siren {
     func processVersionCheck(with payload: [String: Any]) {
         storeVersionCheckDate() // Store version comparison date
 
-        guard let results = payload["results"] as? [[String: Any]] else {
+        guard let results = payload[JSONKeys.results] as? [[String: Any]] else {
             postError(.appStoreVersionNumberFailure, underlyingError: nil)
             return
         }
@@ -201,14 +201,14 @@ private extension Siren {
             return
         }
 
-        guard let appID = info["trackId"] as? Int else {
+        guard let appID = info[JSONKeys.appID] as? Int else {
             postError(.appStoreAppIDFailure, underlyingError: nil)
             return
         }
 
         self.appID = appID
 
-        guard let currentAppStoreVersion = info["version"] as? String else {
+        guard let currentAppStoreVersion = info[JSONKeys.version] as? String else {
             postError(.appStoreVersionArrayFailure, underlyingError: nil)
             return
         }
@@ -221,7 +221,7 @@ private extension Siren {
             return
         }
 
-        guard let currentVersionReleaseDate = info["currentVersionReleaseDate"] as? String,
+        guard let currentVersionReleaseDate = info[JSONKeys.currentVersionReleaseDate] as? String,
             let daysSinceRelease = Date.days(since: currentVersionReleaseDate) else {
             return
         }
@@ -431,9 +431,9 @@ extension Siren {
 
 private extension Siren {
     func isUpdateCompatibleWithDeviceOS(appData: [String: Any]) -> Bool {
-        guard let results = appData["results"] as? [[String: Any]],
+        guard let results = appData[JSONKeys.results] as? [[String: Any]],
             let info = results.first,
-            let requiredOSVersion = info["minimumOsVersion"] as? String else {
+            let requiredOSVersion = info[JSONKeys.minimumOSVersion] as? String else {
                 postError(.appStoreOSVersionNumberFailure, underlyingError: nil)
                 return false
         }
@@ -581,6 +581,14 @@ private extension Siren {
 
         /// Key that stores the version that a user decided to skip in UserDefaults.
         case StoredSkippedVersion
+    }
+
+    struct JSONKeys {
+        static let appID = "trackId"
+        static let currentVersionReleaseDate = "currentVersionReleaseDate"
+        static let minimumOSVersion = "minimumOsVersion"
+        static let results = "results"
+        static let version = "version"
     }
 
 }

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -290,23 +290,22 @@ private extension Siren {
 
     func processResults(withData data: Data?, response: URLResponse?, error: Error?) {
         if let error = error {
-            self.postError(.appStoreDataRetrievalFailure, underlyingError: error)
+            postError(.appStoreDataRetrievalFailure, underlyingError: error)
         } else {
             guard let data = data else {
-                self.postError(.appStoreDataRetrievalFailure, underlyingError: nil)
+                postError(.appStoreDataRetrievalFailure, underlyingError: nil)
                 return
             }
 
             do {
-                let jsonData = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
+                let jsonData = try JSONSerialization.jsonObject(with: data, options: [])
                 guard let appData = jsonData as? [String: Any],
-                    self.isUpdateCompatibleWithDeviceOS(appData: appData) else {
-
-                        self.postError(.appStoreJSONParsingFailure, underlyingError: nil)
+                    isUpdateCompatibleWithDeviceOS(appData: appData) else {
+                        postError(.appStoreJSONParsingFailure, underlyingError: nil)
                         return
                 }
 
-                DispatchQueue.main.async {
+                DispatchQueue.main.async { [unowned self] in
                     // Print iTunesLookup results from appData
                     self.printMessage(message: "JSON results: \(appData)")
 
@@ -315,7 +314,7 @@ private extension Siren {
                 }
 
             } catch let error as NSError {
-                self.postError(.appStoreDataRetrievalFailure, underlyingError: error)
+                postError(.appStoreDataRetrievalFailure, underlyingError: error)
             }
         }
     }
@@ -324,7 +323,7 @@ private extension Siren {
         storeVersionCheckDate() // Store version comparison date
 
         guard let allResults = results["results"] as? [[String: Any]] else {
-            self.postError(.appStoreVersionNumberFailure, underlyingError: nil)
+            postError(.appStoreVersionNumberFailure, underlyingError: nil)
             return
         }
 
@@ -342,7 +341,7 @@ private extension Siren {
         self.appID = appID
 
         guard let currentAppStoreVersion = allResults.first?["version"] as? String else {
-            self.postError(.appStoreVersionArrayFailure, underlyingError: nil)
+            postError(.appStoreVersionArrayFailure, underlyingError: nil)
             return
         }
 

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -8,144 +8,6 @@
 
 import UIKit
 
-// MARK: - SirenDelegate Protocol
-
-/// Delegate that handles all codepaths for Siren upon version check completion.
-public protocol SirenDelegate: class {
-    /// User presented with update dialog
-    func sirenDidShowUpdateDialog(alertType: SirenAlertType)
-
-    /// User did click on button that launched App Store.app
-    func sirenUserDidLaunchAppStore()
-
-    /// User did click on button that skips version update
-    func sirenUserDidSkipVersion()
-
-    /// User did click on button that cancels update dialog
-    func sirenUserDidCancel()
-
-    /// Siren failed to perform version check (may return system-level error)
-    func sirenDidFailVersionCheck(error: NSError)
-
-    /// Siren performed version check and did not display alert
-    func sirenDidDetectNewVersionWithoutAlert(message: String)
-
-    /// Siren performed version check and latest version is installed
-    func sirenLatestVersionInstalled()
-}
-
-// MARK: - SirenDelegate Protocol Extension
-
-public extension SirenDelegate {
-    func sirenDidShowUpdateDialog(alertType: SirenAlertType) {}
-    func sirenUserDidLaunchAppStore() {}
-    func sirenUserDidSkipVersion() {}
-    func sirenUserDidCancel() {}
-    func sirenDidFailVersionCheck(error: NSError) {}
-    func sirenDidDetectNewVersionWithoutAlert(message: String) {}
-    func sirenLatestVersionInstalled() {}
-}
-
-/// Determines the type of alert to present after a successful version check has been performed.
-public enum SirenAlertType {
-    /// Forces user to update your app (1 button alert).
-    case force
-
-    /// (DEFAULT) Presents user with option to update app now or at next launch (2 button alert).
-    case option
-
-    /// Presents user with option to update the app now, at next launch, or to skip this version all together (3 button alert).
-    case skip
-
-    /// Doesn't show the alert, but instead returns a localized message for use in a custom UI within the sirenDidDetectNewVersionWithoutAlert() delegate method.
-    case none
-}
-
-/// Determines the frequency in which the the version check is performed.
-///
-public enum SirenVersionCheckType: Int {
-    /// Version check performed every time the app is launched.
-    case immediately = 0
-
-    /// Version check performed once a day.
-    case daily = 1
-
-    /// Version check performed once a week.
-    case weekly = 7
-}
-
-/// Determines the available languages in which the update message and alert button titles should appear.
-///
-/// By default, the operating system's default lanuage setting is used. However, you can force a specific language
-/// by setting the forceLanguageLocalization property before calling checkVersion()
-public enum SirenLanguageType: String {
-    case Arabic = "ar"
-    case Armenian = "hy"
-    case Basque = "eu"
-    case ChineseSimplified = "zh-Hans"
-    case ChineseTraditional = "zh-Hant"
-    case Croatian = "hr"
-    case Danish = "da"
-    case Dutch = "nl"
-    case English = "en"
-    case Estonian = "et"
-    case Finnish = "fi"
-    case French = "fr"
-    case German = "de"
-    case Greek = "el"
-    case Hebrew = "he"
-    case Hungarian = "hu"
-    case Indonesian = "id"
-    case Italian = "it"
-    case Japanese = "ja"
-    case Korean = "ko"
-    case Latvian = "lv"
-    case Lithuanian = "lt"
-    case Malay = "ms"
-    case Norwegian = "nb-NO"
-    case Polish = "pl"
-    case PortugueseBrazil = "pt"
-    case PortuguesePortugal = "pt-PT"
-    case Russian = "ru"
-    case SerbianCyrillic = "sr-Cyrl"
-    case SerbianLatin = "sr-Latn"
-    case Slovenian = "sl"
-    case Spanish = "es"
-    case Swedish = "sv"
-    case Thai = "th"
-    case Turkish = "tr"
-    case Vietnamese = "vi"
-}
-
-/// Siren-specific Error Codes
-private enum SirenErrorCode: Int {
-    case malformedURL = 1000
-    case recentlyCheckedAlready
-    case noUpdateAvailable
-    case appStoreDataRetrievalFailure
-    case appStoreJSONParsingFailure
-    case appStoreOSVersionNumberFailure
-    case appStoreOSVersionUnsupported
-    case appStoreVersionNumberFailure
-    case appStoreVersionArrayFailure
-    case appStoreAppIDFailure
-}
-
-/// Siren-specific Throwable Errors
-private enum SirenError: Error {
-    case malformedURL
-    case missingBundleIdOrAppId
-}
-
-/// Siren-specific UserDefaults Keys
-private enum SirenUserDefaults: String {
-    /// Key that stores the timestamp of the last version check in UserDefaults
-    case StoredVersionCheckDate
-
-    /// Key that stores the version that a user decided to skip in UserDefaults.
-    case StoredSkippedVersion
-}
-
 // MARK: - Siren
 
 /// The Siren Class. A singleton that is initialized using the shared() method.
@@ -162,7 +24,7 @@ public final class Siren: NSObject {
     /// The SirenDelegate variable, which should be set if you'd like to be notified:
     ///
     /// When a user views or interacts with the alert
-    /// - sirenDidShowUpdateDialog(alertType: SirenAlertType)
+    /// - sirenDidShowUpdateDialog(alertType: AlertType)
     /// - sirenUserDidLaunchAppStore()
     /// - sirenUserDidSkipVersion()
     /// - sirenUserDidCancel()
@@ -177,7 +39,7 @@ public final class Siren: NSObject {
 
     /// Determines the type of alert that should be shown.
     /// See the SirenAlertType enum for full details.
-    public var alertType = SirenAlertType.option {
+    public var alertType = AlertType.option {
         didSet {
             majorUpdateAlertType = alertType
             minorUpdateAlertType = alertType
@@ -189,22 +51,22 @@ public final class Siren: NSObject {
     /// Determines the type of alert that should be shown for major version updates: A.b.c
     /// Defaults to SirenAlertType.Option.
     /// See the SirenAlertType enum for full details.
-    public lazy var majorUpdateAlertType = SirenAlertType.option
+    public lazy var majorUpdateAlertType = AlertType.option
 
     /// Determines the type of alert that should be shown for minor version updates: a.B.c
     /// Defaults to SirenAlertType.Option.
     /// See the SirenAlertType enum for full details.
-    public lazy var minorUpdateAlertType  = SirenAlertType.option
+    public lazy var minorUpdateAlertType  = AlertType.option
 
     /// Determines the type of alert that should be shown for minor patch updates: a.b.C
     /// Defaults to SirenAlertType.Option.
     /// See the SirenAlertType enum for full details.
-    public lazy var patchUpdateAlertType = SirenAlertType.option
+    public lazy var patchUpdateAlertType = AlertType.option
 
     /// Determines the type of alert that should be shown for revision updates: a.b.c.D
     /// Defaults to SirenAlertType.Option.
     /// See the SirenAlertType enum for full details.
-    public lazy var revisionUpdateAlertType = SirenAlertType.option
+    public lazy var revisionUpdateAlertType = AlertType.option
 
     /// The name of your app.
     /// By default, it's set to the name of the app that's stored in your plist.
@@ -217,7 +79,7 @@ public final class Siren: NSObject {
 
     /// Overrides the default localization of a user's device when presenting the update message and button titles in the alert.
     /// See the SirenLanguageType enum for more details.
-    public var forceLanguageLocalization: SirenLanguageType?
+    public var forceLanguageLocalization: Siren.LanguageType?
 
     /// Overrides the tint color for UIAlertController.
     public var alertControllerTintColor: UIColor?
@@ -310,7 +172,7 @@ private extension Siren {
                     self.printMessage(message: "JSON results: \(appData)")
 
                     // Process Results (e.g., extract current version that is available on the AppStore)
-                    self.processVersionCheck(withResults: appData)
+                    self.processVersionCheck(with: appData)
                 }
 
             } catch let error as NSError {
@@ -319,28 +181,33 @@ private extension Siren {
         }
     }
 
-    func processVersionCheck(withResults results: [String: Any]) {
+    func processVersionCheck(with payload: [String: Any]) {
         storeVersionCheckDate() // Store version comparison date
 
-        guard let allResults = results["results"] as? [[String: Any]] else {
+        guard let results = payload["results"] as? [[String: Any]] else {
             postError(.appStoreVersionNumberFailure, underlyingError: nil)
             return
         }
 
         /// Condition satisfied when app not in App Store
-        guard !allResults.isEmpty else {
+        guard !results.isEmpty else {
             postError(.appStoreDataRetrievalFailure, underlyingError: nil)
             return
         }
 
-        guard let appID = allResults.first?["trackId"] as? Int else {
+        guard let info = results.first else {
+            postError(.appStoreDataRetrievalFailure, underlyingError: nil)
+            return
+        }
+
+        guard let appID = info["trackId"] as? Int else {
             postError(.appStoreAppIDFailure, underlyingError: nil)
             return
         }
 
         self.appID = appID
 
-        guard let currentAppStoreVersion = allResults.first?["version"] as? String else {
+        guard let currentAppStoreVersion = info["version"] as? String else {
             postError(.appStoreVersionArrayFailure, underlyingError: nil)
             return
         }
@@ -358,7 +225,7 @@ private extension Siren {
             return
         }
 
-        guard let currentVersionReleaseDate = allResults.first?["currentVersionReleaseDate"] as? String,
+        guard let currentVersionReleaseDate = info["currentVersionReleaseDate"] as? String,
             let daysSinceRelease = Date.days(since: currentVersionReleaseDate),
             daysSinceRelease >= alertDays else {
                 return
@@ -481,7 +348,7 @@ private extension Siren {
         return action
     }
 
-    func setAlertType() -> SirenAlertType {
+    func setAlertType() -> Siren.AlertType {
         guard let currentInstalledVersion = currentInstalledVersion,
             let currentAppStoreVersion = currentAppStoreVersion else {
                 return .option
@@ -606,10 +473,119 @@ private extension Siren {
     }
 }
 
+// MARK: - Enumerated Types (Public)
+
+public extension Siren {
+    /// Determines the type of alert to present after a successful version check has been performed.
+    enum AlertType {
+        /// Forces user to update your app (1 button alert).
+        case force
+
+        /// (DEFAULT) Presents user with option to update app now or at next launch (2 button alert).
+        case option
+
+        /// Presents user with option to update the app now, at next launch, or to skip this version all together (3 button alert).
+        case skip
+
+        /// Doesn't show the alert, but instead returns a localized message for use in a custom UI within the sirenDidDetectNewVersionWithoutAlert() delegate method.
+        case none
+    }
+
+    /// Determines the frequency in which the the version check is performed and the user is prompted to update the app.
+    ///
+    enum SirenVersionCheckType: Int {
+        /// Version check performed every time the app is launched.
+        case immediately = 0
+
+        /// Version check performed once a day.
+        case daily = 1
+
+        /// Version check performed once a week.
+        case weekly = 7
+    }
+
+    /// Determines the available languages in which the update message and alert button titles should appear.
+    ///
+    /// By default, the operating system's default lanuage setting is used. However, you can force a specific language
+    /// by setting the forceLanguageLocalization property before calling checkVersion()
+    enum LanguageType: String {
+        case Arabic = "ar"
+        case Armenian = "hy"
+        case Basque = "eu"
+        case ChineseSimplified = "zh-Hans"
+        case ChineseTraditional = "zh-Hant"
+        case Croatian = "hr"
+        case Danish = "da"
+        case Dutch = "nl"
+        case English = "en"
+        case Estonian = "et"
+        case Finnish = "fi"
+        case French = "fr"
+        case German = "de"
+        case Greek = "el"
+        case Hebrew = "he"
+        case Hungarian = "hu"
+        case Indonesian = "id"
+        case Italian = "it"
+        case Japanese = "ja"
+        case Korean = "ko"
+        case Latvian = "lv"
+        case Lithuanian = "lt"
+        case Malay = "ms"
+        case Norwegian = "nb-NO"
+        case Polish = "pl"
+        case PortugueseBrazil = "pt"
+        case PortuguesePortugal = "pt-PT"
+        case Russian = "ru"
+        case SerbianCyrillic = "sr-Cyrl"
+        case SerbianLatin = "sr-Latn"
+        case Slovenian = "sl"
+        case Spanish = "es"
+        case Swedish = "sv"
+        case Thai = "th"
+        case Turkish = "tr"
+        case Vietnamese = "vi"
+    }
+}
+
+// MARK: - Enumerated Types (Private)
+
+private extension Siren {
+    /// Siren-specific Error Codes
+    enum ErrorCode: Int {
+        case malformedURL = 1000
+        case recentlyCheckedAlready
+        case noUpdateAvailable
+        case appStoreDataRetrievalFailure
+        case appStoreJSONParsingFailure
+        case appStoreOSVersionNumberFailure
+        case appStoreOSVersionUnsupported
+        case appStoreVersionNumberFailure
+        case appStoreVersionArrayFailure
+        case appStoreAppIDFailure
+    }
+
+    /// Siren-specific Throwable Errors
+    enum SirenError: Error {
+        case malformedURL
+        case missingBundleIdOrAppId
+    }
+
+    /// Siren-specific UserDefaults Keys
+    enum SirenUserDefaults: String {
+        /// Key that stores the timestamp of the last version check in UserDefaults
+        case StoredVersionCheckDate
+
+        /// Key that stores the version that a user decided to skip in UserDefaults.
+        case StoredSkippedVersion
+    }
+
+}
+
 // MARK: - Error Handling
 
 private extension Siren {
-    func postError(_ code: SirenErrorCode, underlyingError: Error?) {
+    func postError(_ code: ErrorCode, underlyingError: Error?) {
         let description: String
 
         switch code {

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -227,7 +227,7 @@ private extension Siren {
         }
 
         guard daysSinceRelease >= showAlertAfterCurrentVersionHasBeenReleasedForDays else {
-            let message = "Your app has been released for \(daysSinceRelease) days, but Siren cannot prompt the user until \(showAlertAfterCurrentVersionHasBeenReleasedForDays) days have passed"
+            let message = "Your app has been released for \(daysSinceRelease) days, but Siren cannot prompt the user until \(showAlertAfterCurrentVersionHasBeenReleasedForDays) days have passed."
             self.printMessage(message: message)
             return
         }

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -440,13 +440,13 @@ private extension Siren {
 
         let systemVersion = UIDevice.current.systemVersion
 
-        if systemVersion.compare(requiredOSVersion, options: .numeric) == .orderedDescending ||
-            systemVersion.compare(requiredOSVersion, options: .numeric) == .orderedSame {
-            return true
-        } else {
+        guard systemVersion.compare(requiredOSVersion, options: .numeric) == .orderedDescending ||
+            systemVersion.compare(requiredOSVersion, options: .numeric) == .orderedSame else {
             postError(.appStoreOSVersionUnsupported, underlyingError: nil)
             return false
         }
+
+        return true
     }
 
     func hideWindow() {

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -487,7 +487,8 @@ public extension Siren {
         /// Presents user with option to update the app now, at next launch, or to skip this version all together (3 button alert).
         case skip
 
-        /// Doesn't show the alert, but instead returns a localized message for use in a custom UI within the sirenDidDetectNewVersionWithoutAlert() delegate method.
+        /// Doesn't show the alert, but instead returns a localized message 
+        /// for use in a custom UI within the sirenDidDetectNewVersionWithoutAlert() delegate method.
         case none
     }
 

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -629,4 +629,3 @@ private extension Siren {
         printMessage(message: error.localizedDescription)
     }
 }
-

--- a/Sources/SirenBundleExtension.swift
+++ b/Sources/SirenBundleExtension.swift
@@ -19,13 +19,13 @@ internal extension Bundle {
         return Bundle(for: Siren.self).path(forResource: "Siren", ofType: "bundle") as String!
     }
 
-    func sirenForcedBundlePath(forceLanguageLocalization: SirenLanguageType) -> String {
+    func sirenForcedBundlePath(forceLanguageLocalization: Siren.LanguageType) -> String {
         let path = sirenBundlePath()
         let name = forceLanguageLocalization.rawValue
         return Bundle(path: path)!.path(forResource: name, ofType: "lproj")!
     }
 
-    func localizedString(stringKey: String, forceLanguageLocalization: SirenLanguageType?) -> String {
+    func localizedString(stringKey: String, forceLanguageLocalization: Siren.LanguageType?) -> String {
         var path: String
         let table = "SirenLocalizable"
         if let forceLanguageLocalization = forceLanguageLocalization {
@@ -48,7 +48,7 @@ internal extension Bundle {
 // MARK: - Bundle Extension for Testing Siren
 
 extension Bundle {
-    func testLocalizedString(stringKey: String, forceLanguageLocalization: SirenLanguageType?) -> String {
+    func testLocalizedString(stringKey: String, forceLanguageLocalization: Siren.LanguageType?) -> String {
         return Bundle().localizedString(stringKey: stringKey, forceLanguageLocalization: forceLanguageLocalization)
     }
 }

--- a/Sources/SirenDateExtension.swift
+++ b/Sources/SirenDateExtension.swift
@@ -19,7 +19,9 @@ internal extension Date {
         let dateformatter = DateFormatter()
         dateformatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
 
-        guard let releaseDate = dateformatter.date(from: dateString) else { return nil }
+        guard let releaseDate = dateformatter.date(from: dateString) else {
+            return nil
+        }
 
         return days(since: releaseDate)
     }

--- a/Sources/SirenDelegate.swift
+++ b/Sources/SirenDelegate.swift
@@ -1,0 +1,47 @@
+//
+//  SirenDelegate.swift
+//  SirenExample
+//
+//  Created by Arthur Sabintsev on 4/8/17.
+//  Copyright © 2017 Sabintsev iOS Projects. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - SirenDelegate Protocol
+
+/// Delegate that handles all codepaths for Siren upon version check completion.
+public protocol SirenDelegate: class {
+    /// User presented with update dialog
+    func sirenDidShowUpdateDialog(alertType: Siren.AlertType)
+
+    /// User did click on button that launched App Store.app
+    func sirenUserDidLaunchAppStore()
+
+    /// User did click on button that skips version update
+    func sirenUserDidSkipVersion()
+
+    /// User did click on button that cancels update dialog
+    func sirenUserDidCancel()
+
+    /// Siren failed to perform version check (may return system-level error)
+    func sirenDidFailVersionCheck(error: NSError)
+
+    /// Siren performed version check and did not display alert
+    func sirenDidDetectNewVersionWithoutAlert(message: String)
+
+    /// Siren performed version check and latest version is installed
+    func sirenLatestVersionInstalled()
+}
+
+// MARK: - SirenDelegate Protocol Extension
+
+public extension SirenDelegate {
+    func sirenDidShowUpdateDialog(alertType: Siren.AlertType) {}
+    func sirenUserDidLaunchAppStore() {}
+    func sirenUserDidSkipVersion() {}
+    func sirenUserDidCancel() {}
+    func sirenDidFailVersionCheck(error: NSError) {}
+    func sirenDidDetectNewVersionWithoutAlert(message: String) {}
+    func sirenLatestVersionInstalled() {}
+}

--- a/Sources/SirenDelegate.swift
+++ b/Sources/SirenDelegate.swift
@@ -12,36 +12,58 @@ import Foundation
 
 /// Delegate that handles all codepaths for Siren upon version check completion.
 public protocol SirenDelegate: class {
-    /// User presented with update dialog
+    /// User presented with update dialog.
     func sirenDidShowUpdateDialog(alertType: Siren.AlertType)
 
-    /// User did click on button that launched App Store.app
+    /// User did click on button that launched App Store.app.
     func sirenUserDidLaunchAppStore()
 
-    /// User did click on button that skips version update
+    /// User did click on button that skips version update.
     func sirenUserDidSkipVersion()
 
-    /// User did click on button that cancels update dialog
+    /// User did click on button that cancels update dialog.
     func sirenUserDidCancel()
 
-    /// Siren failed to perform version check (may return system-level error)
+    /// Siren failed to perform version check (may return system-level error).
     func sirenDidFailVersionCheck(error: NSError)
 
-    /// Siren performed version check and did not display alert
+    /// Siren performed version check and did not display alert.
     func sirenDidDetectNewVersionWithoutAlert(message: String)
 
-    /// Siren performed version check and latest version is installed
+    /// Siren performed version check and latest version is installed.
     func sirenLatestVersionInstalled()
 }
 
 // MARK: - SirenDelegate Protocol Extension
 
 public extension SirenDelegate {
-    func sirenDidShowUpdateDialog(alertType: Siren.AlertType) {}
-    func sirenUserDidLaunchAppStore() {}
-    func sirenUserDidSkipVersion() {}
-    func sirenUserDidCancel() {}
-    func sirenDidFailVersionCheck(error: NSError) {}
-    func sirenDidDetectNewVersionWithoutAlert(message: String) {}
-    func sirenLatestVersionInstalled() {}
+
+    func sirenDidShowUpdateDialog(alertType: Siren.AlertType) {
+        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+    }
+
+    func sirenUserDidLaunchAppStore() {
+        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+    }
+
+    func sirenUserDidSkipVersion() {
+        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+    }
+
+    func sirenUserDidCancel() {
+        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+    }
+
+    func sirenDidFailVersionCheck(error: NSError) {
+        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+    }
+
+    func sirenDidDetectNewVersionWithoutAlert(message: String) {
+        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+    }
+
+    func sirenLatestVersionInstalled() {
+        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+    }
+
 }

--- a/Sources/SirenTestHelper.swift
+++ b/Sources/SirenTestHelper.swift
@@ -1,0 +1,25 @@
+//
+//  SirenTestHelper.swift
+//  SirenExample
+//
+//  Created by Arthur Sabintsev on 4/8/17.
+//  Copyright © 2017 Sabintsev iOS Projects. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Helpers (Testing Target)
+
+extension Siren {
+    func testSetCurrentInstalledVersion(version: String) {
+        currentInstalledVersion = version
+    }
+
+    func testSetAppStoreVersion(version: String) {
+        currentAppStoreVersion = version
+    }
+
+    func testIsAppStoreVersionNewer() -> Bool {
+        return isAppStoreVersionNewer()
+    }
+}


### PR DESCRIPTION
- Siren.swift has seen a fairly large refactor
  - `SirenDelegate` has move to SirenDelegate.swift
  - SirenTestHelper.swift now contains the XCTest Helper functions
  - Public and private enums have changed their names and scope
    - e.g. `SirenLanguageType -> `Siren.LanguageType`
    - e.g. `SirenAlertType -> `Siren.AlertType`
- `showAlertAfterCurrentVersionHasBeenReleasedForDays` changed from `Int?` to `Int` and now has a default value of `1` to avoid a timing issue between the App Store JSON being updated faster than the App Store receiving your updated app binary.

I've also made the code more readable, by adding more:
- error handling
- debug messages
- documentation