### PR TITLE
[Bug fix] set "en_US_POSIX" as the locale of the date formatter

### DIFF
--- a/Sources/SirenDateExtension.swift
+++ b/Sources/SirenDateExtension.swift
@@ -17,6 +17,7 @@ internal extension Date {
 
     static func days(since dateString: String) -> Int? {
         let dateformatter = DateFormatter()
+        dateformatter.locale = Locale(identifier: "en_US_POSIX")
         dateformatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
 
         guard let releaseDate = dateformatter.date(from: dateString) else {


### PR DESCRIPTION
Hi there,

It seems like Siren doesn’t work due to a dateFormatter issue in case a user turns off 24-Hour Time or sets to the Japanese Calendar on the iPhone.
https://github.com/ArtSabintsev/Siren/blob/master/Sources/SirenDateExtension.swift#L19-L24

Hope this PR will be merged soon. Thanks!
