### PR TITLE
Added SirenLog. Removed assertionFailures on default implementations …

### DIFF
--- a/SirenExample/SirenExample.xcodeproj/project.pbxproj
+++ b/SirenExample/SirenExample.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		8E43D6231E8223EE00ECFFC8 /* SirenDateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */; };
 		8E528A301E989A7A00B643C4 /* SirenDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */; };
 		8E528A321E989E0A00B643C4 /* SirenTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E528A311E989E0A00B643C4 /* SirenTestHelper.swift */; };
+		8E5D15B11F3632D7001C0960 /* SirenLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E5D15B01F3632D7001C0960 /* SirenLog.swift */; };
 		8E9C238B1E7CDB42000ED3DA /* SirenBundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */; };
 		8E9C238D1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C238C1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift */; };
 		8E9C238F1E7CDDE7000ED3DA /* SirenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C238E1E7CDDE7000ED3DA /* SirenViewController.swift */; };
@@ -67,6 +68,7 @@
 		8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenDateExtension.swift; path = ../../Sources/SirenDateExtension.swift; sourceTree = "<group>"; };
 		8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenDelegate.swift; path = ../../Sources/SirenDelegate.swift; sourceTree = "<group>"; };
 		8E528A311E989E0A00B643C4 /* SirenTestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenTestHelper.swift; path = ../../Sources/SirenTestHelper.swift; sourceTree = "<group>"; };
+		8E5D15B01F3632D7001C0960 /* SirenLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenLog.swift; path = ../../Sources/SirenLog.swift; sourceTree = "<group>"; };
 		8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenBundleExtension.swift; path = ../../Sources/SirenBundleExtension.swift; sourceTree = "<group>"; };
 		8E9C238C1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenUIAlertControllerExtension.swift; path = ../../Sources/SirenUIAlertControllerExtension.swift; sourceTree = "<group>"; };
 		8E9C238E1E7CDDE7000ED3DA /* SirenViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenViewController.swift; path = ../../Sources/SirenViewController.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */,
 				8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */,
 				8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */,
+				8E5D15B01F3632D7001C0960 /* SirenLog.swift */,
 				8E528A311E989E0A00B643C4 /* SirenTestHelper.swift */,
 				8E9C238C1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift */,
 				8E9C238E1E7CDDE7000ED3DA /* SirenViewController.swift */,
@@ -348,6 +351,7 @@
 				8E9C238F1E7CDDE7000ED3DA /* SirenViewController.swift in Sources */,
 				55EC36611E6BB99B00726F13 /* Siren.swift in Sources */,
 				8E43D6231E8223EE00ECFFC8 /* SirenDateExtension.swift in Sources */,
+				8E5D15B11F3632D7001C0960 /* SirenLog.swift in Sources */,
 				8E9C238B1E7CDB42000ED3DA /* SirenBundleExtension.swift in Sources */,
 				8E528A301E989A7A00B643C4 /* SirenDelegate.swift in Sources */,
 				8E9C238D1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift in Sources */,

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -34,7 +34,7 @@ public final class Siren: NSObject {
     public weak var delegate: SirenDelegate?
 
     /// The debug flag, which is disabled by default.
-    /// When enabled, a stream of println() statements are logged to your console when a version check is performed.
+    /// When enabled, a stream of print() statements are logged to your console when a version check is performed.
     public lazy var debugEnabled = false
 
     /// Determines the type of alert that should be shown.
@@ -114,7 +114,7 @@ public final class Siren: NSObject {
     ///   - checkType: The frequency in days in which you want a check to be performed. Please refer to the Siren.VersionCheckType enum for more details.
     public func checkVersion(checkType: VersionCheckType) {
         guard let _ = Bundle.bundleID() else {
-            printMessage(message: "Please make sure that you have set a `Bundle Identifier` in your project.")
+            printMessage("Please make sure that you have set a `Bundle Identifier` in your project.")
             return
         }
 
@@ -170,7 +170,7 @@ private extension Siren {
 
                 DispatchQueue.main.async { [unowned self] in
                     // Print iTunesLookup results from appData
-                    self.printMessage(message: "JSON results: \(appData)")
+                    self.printMessage("JSON results: \(appData)")
 
                     // Process Results (e.g., extract current version that is available on the AppStore)
                     self.processVersionCheck(with: appData)
@@ -228,7 +228,7 @@ private extension Siren {
 
         guard daysSinceRelease >= showAlertAfterCurrentVersionHasBeenReleasedForDays else {
             let message = "Your app has been released for \(daysSinceRelease) days, but Siren cannot prompt the user until \(showAlertAfterCurrentVersionHasBeenReleasedForDays) days have passed."
-            self.printMessage(message: message)
+            self.printMessage(message)
             return
         }
 
@@ -467,9 +467,12 @@ private extension Siren {
         }
     }
 
-    func printMessage(message: String) {
+    /// Routes a console-bound message to the `SirenLog` struct, which decorates the log message.
+    ///
+    /// - Parameter message: The message to decorate and log to the console.
+    func printMessage(_ message: String) {
         if debugEnabled {
-            print("[Siren] \(message)")
+            SirenLog(message)
         }
     }
 }
@@ -639,6 +642,6 @@ private extension Siren {
 
         delegate?.sirenDidFailVersionCheck(error: error)
 
-        printMessage(message: error.localizedDescription)
+        printMessage(error.localizedDescription)
     }
 }

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -133,6 +133,22 @@ public final class Siren: NSObject {
             }
         }
     }
+
+    /// Launches the AppStore in two situations:
+    /// 
+    /// - User clicked the `Update` button in the UIAlertController modal.
+    /// - Developer built a custom alert modal and needs to be able to call this function when the user chooses to update the app in the aforementioned custom modal.
+    public func launchAppStore() {
+        guard let appID = appID,
+            let iTunesURL = URL(string: "https://itunes.apple.com/app/id\(appID)") else {
+                return
+        }
+
+        DispatchQueue.main.async {
+            UIApplication.shared.openURL(iTunesURL)
+        }
+    }
+
 }
 
 // MARK: - Helpers (Networking)
@@ -453,17 +469,6 @@ private extension Siren {
         if let updaterWindow = updaterWindow {
             updaterWindow.isHidden = true
             self.updaterWindow = nil
-        }
-    }
-
-    func launchAppStore() {
-        guard let appID = appID,
-            let iTunesURL = URL(string: "https://itunes.apple.com/app/id\(appID)") else {
-            return
-        }
-
-        DispatchQueue.main.async {
-            UIApplication.shared.openURL(iTunesURL)
         }
     }
 

--- a/Sources/SirenDelegate.swift
+++ b/Sources/SirenDelegate.swift
@@ -39,31 +39,35 @@ public protocol SirenDelegate: class {
 public extension SirenDelegate {
 
     func sirenDidShowUpdateDialog(alertType: Siren.AlertType) {
-        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+        printMessage()
     }
 
     func sirenUserDidLaunchAppStore() {
-        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+        printMessage()
     }
 
     func sirenUserDidSkipVersion() {
-        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+        printMessage()
     }
 
     func sirenUserDidCancel() {
-        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+        printMessage()
     }
 
     func sirenDidFailVersionCheck(error: NSError) {
-        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+        printMessage()
     }
 
     func sirenDidDetectNewVersionWithoutAlert(message: String) {
-        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+        printMessage()
     }
 
     func sirenLatestVersionInstalled() {
-        assertionFailure("An attempt to reach \(#function) failed as it was called without being implemented.")
+        printMessage()
+    }
+
+    private func printMessage(_ function: String = #function) {
+        SirenLog("The default implementation of \(function) is being called. You can ignore this message if you do not care to implement this method in your `SirenDelegate` conforming structure.")
     }
 
 }

--- a/Sources/SirenLog.swift
+++ b/Sources/SirenLog.swift
@@ -1,0 +1,20 @@
+//
+//  SirenLog.swift
+//  SirenExample
+//
+//  Created by Arthur Sabintsev on 8/5/17.
+//  Copyright © 2017 Sabintsev iOS Projects. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Log and decorate Siren-specific messages to the console.
+
+struct SirenLog {
+
+    @discardableResult
+    init(_ message: String) {
+        print("[Siren] \(message)")
+    }
+
+}


### PR DESCRIPTION
- Added `SirenLog`, which prints out decorated, Siren-specific messages to the console.
- Replaced `assertionFailure` calls with `SirenLog` on default implementations of methods defined by `SirenDelegate`.
- Fixes #155. 
- Fixes #156.