### PR TITLE
Resolve accessibility issues

### DIFF
--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -92,9 +92,9 @@ public final class Siren: NSObject {
     public internal(set) var currentAppStoreVersion: String?
 
     internal var updaterWindow: UIWindow?
-    private var appID: Int?
-    private var lastVersionCheckPerformedOnDate: Date?
-    private lazy var alertViewIsVisible: Bool = false
+    fileprivate var appID: Int?
+    fileprivate var lastVersionCheckPerformedOnDate: Date?
+    fileprivate lazy var alertViewIsVisible: Bool = false
 
     /// The App's Singleton
     public static let shared = Siren()
@@ -413,7 +413,7 @@ extension Siren {
         return newVersionExists
     }
 
-    private func storeVersionCheckDate() {
+    fileprivate func storeVersionCheckDate() {
         lastVersionCheckPerformedOnDate = Date()
         if let lastVersionCheckPerformedOnDate = lastVersionCheckPerformedOnDate {
             UserDefaults.standard.set(lastVersionCheckPerformedOnDate, forKey: SirenDefaults.StoredVersionCheckDate.rawValue)


### PR DESCRIPTION
A few variables and one function had private access and errors were thrown in Xcode 9 GM release stating they were inaccessible, changed to fileprivate to resolve this issue.