### PR TITLE
'characters' is deprecated in Swift 4

### DIFF
--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -358,8 +358,8 @@ private extension Siren {
                 return .option
         }
 
-        let oldVersion = (currentInstalledVersion).characters.split {$0 == "."}.map { String($0) }.map {Int($0) ?? 0}
-        let newVersion = (currentAppStoreVersion).characters.split {$0 == "."}.map { String($0) }.map {Int($0) ?? 0}
+        let oldVersion = (currentInstalledVersion).split {$0 == "."}.map { String($0) }.map {Int($0) ?? 0}
+        let newVersion = (currentAppStoreVersion).split {$0 == "."}.map { String($0) }.map {Int($0) ?? 0}
 
         guard let newVersionFirst = newVersion.first, let oldVersionFirst = oldVersion.first else {
             return alertType // Default value is .Option


### PR DESCRIPTION
Silence a warning in Xcode 9.1 beta (naturally, works in 9.0 as well)