### PR TITLE
Add import UIKit for compilation as static framework.

### DIFF
--- a/Sources/SirenUIAlertControllerExtension.swift
+++ b/Sources/SirenUIAlertControllerExtension.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 // MARK: - UIAlertController Extension for Siren
 

--- a/Sources/SirenViewController.swift
+++ b/Sources/SirenViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 // MARK: - UIViewController Extension for Siren
 


### PR DESCRIPTION
Import UIKit is necessary for compilation as static framework.