### PR TITLE
Annoying alerts everytime app is switched to foreground from background even after clicking "Next Time" button in the alert

### DIFF
--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -36,6 +36,11 @@ public final class Siren: NSObject {
     /// The debug flag, which is disabled by default.
     /// When enabled, a stream of print() statements are logged to your console when a version check is performed.
     public lazy var debugEnabled = false
+  
+    /// The shouldNotPropmtUserInThisSession flag, which is disabled by default.
+    /// If VersionCheckType is .immediate, and you are checking version in applicationWillEnterForeground method, then susequent jumps from background to foreground will not trigger annoying alerts to user if user has clicked "NextTime" button in the alert.
+    /// This is only applicable for .immediate VersionCheckType and it will be effective until the application is relaunched.
+    public lazy var shouldNotPropmtUserInThisSession = false
 
     /// Determines the type of alert that should be shown.
     /// See the Siren.AlertType enum for full details.
@@ -124,7 +129,9 @@ public final class Siren: NSObject {
         }
 
         if checkType == .immediately {
+          if !shouldNotPropmtUserInThisSession {
             performVersionCheck()
+          }
         } else {
             guard let lastVersionCheckPerformedOnDate = lastVersionCheckPerformedOnDate else {
                 performVersionCheck()
@@ -330,7 +337,7 @@ private extension Siren {
             self.alertViewIsVisible = false
             return
         }
-
+        shouldNotPropmtUserInThisSession = true
         return action
     }
 

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -38,9 +38,9 @@ public final class Siren: NSObject {
     public lazy var debugEnabled = false
   
     /// The shouldNotPropmtUserInThisSession flag, which is disabled by default.
-    /// If VersionCheckType is .immediate, and you are checking version in applicationWillEnterForeground method, then susequent jumps from background to foreground will not trigger annoying alerts to user if user has clicked "NextTime" button in the alert.
+    /// If VersionCheckType is .immediate, and you are checking version in applicationWillEnterForeground method, then subsequent jumps from background to foreground will not trigger annoying alerts to the user if the user has already clicked "NextTime" button in the alert.
     /// This is only applicable for .immediate VersionCheckType and it will be effective until the application is relaunched.
-    public lazy var shouldNotPropmtUserInThisSession = false
+    private lazy var shouldNotPropmtUserInThisSession = false
 
     /// Determines the type of alert that should be shown.
     /// See the Siren.AlertType enum for full details.


### PR DESCRIPTION

Noticed an issue when I had put **Siren.shared.checkVersion(checkType: .immediately) in applicationWillEnterForeground**,
Whenever I jump from background to foreground, an annoying alert appears for an update even when I click on "Next Time" button.
  
To fix this, I've added a flag: **shouldNotPropmtUserInThisSession** defaulted to false for each session and it changes to true if the user clicks "NextTime" button in the alert.

Note: This is only applicable for .immediate VersionCheckType and it will be effective until the application is **relaunched**.