### PR TITLE
Override Siren's Default Copy/Messaging in UIAlertController/UIAlertActionSheet

### DIFF
--- a/SirenExample/SirenExample.xcodeproj/project.pbxproj
+++ b/SirenExample/SirenExample.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		55EC36601E6BB99B00726F13 /* Siren.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 55EC365E1E6BB99B00726F13 /* Siren.bundle */; };
 		55EC36611E6BB99B00726F13 /* Siren.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC365F1E6BB99B00726F13 /* Siren.swift */; };
 		8E1635A91E6A0B9C0060CE27 /* SirenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE6C74C1E6A0AE100DBE454 /* SirenTests.swift */; };
+		8E2499BF1FD83DDF00F384BA /* SirenAlertMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E2499BE1FD83DDF00F384BA /* SirenAlertMessaging.swift */; };
 		8E43D6231E8223EE00ECFFC8 /* SirenDateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */; };
 		8E528A301E989A7A00B643C4 /* SirenDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */; };
 		8E528A321E989E0A00B643C4 /* SirenTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E528A311E989E0A00B643C4 /* SirenTestHelper.swift */; };
@@ -66,6 +67,7 @@
 		55EC364A1E6BB98A00726F13 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55EC365E1E6BB99B00726F13 /* Siren.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = Siren.bundle; path = ../../Sources/Siren.bundle; sourceTree = "<group>"; };
 		55EC365F1E6BB99B00726F13 /* Siren.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Siren.swift; path = ../../Sources/Siren.swift; sourceTree = "<group>"; };
+		8E2499BE1FD83DDF00F384BA /* SirenAlertMessaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SirenAlertMessaging.swift; path = ../../Sources/SirenAlertMessaging.swift; sourceTree = "<group>"; };
 		8E3A6C041D07CB6F00A8B7CF /* SirenExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SirenExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenDateExtension.swift; path = ../../Sources/SirenDateExtension.swift; sourceTree = "<group>"; };
 		8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SirenDelegate.swift; path = ../../Sources/SirenDelegate.swift; sourceTree = "<group>"; };
@@ -118,9 +120,10 @@
 			children = (
 				55EC365E1E6BB99B00726F13 /* Siren.bundle */,
 				55EC365F1E6BB99B00726F13 /* Siren.swift */,
-				8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */,
+				8E2499BE1FD83DDF00F384BA /* SirenAlertMessaging.swift */,
 				8E9C238A1E7CDB42000ED3DA /* SirenBundleExtension.swift */,
 				8E43D6221E8223EE00ECFFC8 /* SirenDateExtension.swift */,
+				8E528A2F1E989A7A00B643C4 /* SirenDelegate.swift */,
 				8EACA9761F38113D003134CA /* SirenError.swift */,
 				8E5D15B01F3632D7001C0960 /* SirenLog.swift */,
 				8EACA96F1F37F327003134CA /* SirenLookupModel.swift */,
@@ -360,6 +363,7 @@
 				8E5D15B11F3632D7001C0960 /* SirenLog.swift in Sources */,
 				8E9C238B1E7CDB42000ED3DA /* SirenBundleExtension.swift in Sources */,
 				8E528A301E989A7A00B643C4 /* SirenDelegate.swift in Sources */,
+				8E2499BF1FD83DDF00F384BA /* SirenAlertMessaging.swift in Sources */,
 				8EACA9701F37F327003134CA /* SirenLookupModel.swift in Sources */,
 				8E9C238D1E7CDD31000ED3DA /* SirenUIAlertControllerExtension.swift in Sources */,
 			);
@@ -621,7 +625,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/SirenExample/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.starry.youshi;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apple.itunesconnect.mobile;
 				PRODUCT_NAME = SirenExample;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
@@ -636,7 +640,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/SirenExample/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.starry.youshi;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apple.itunesconnect.mobile;
 				PRODUCT_NAME = SirenExample;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;

--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -35,11 +35,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 //        siren.appName = "Test App Name"
 
         // Optional - Change the various UIAlertController and UIAlertAction messaging. One or more values can be changes. If only a subset of values are changed, the defaults with which Siren comes with will be used.
-        siren.alertMessaging = SirenAlertMessaging(updateTitle: "New Fancy Title",
-                                                   updateMessage: "New message goes here!",
-                                                   updateButtonMessage: "Update Now, Plz!?",
-                                                   nextTimeButtonMessage: "OK, next time it is!",
-                                                   skipVersionButtonMessage: "Please don't push skip, please don't!")
+//        siren.alertMessaging = SirenAlertMessaging(updateTitle: "New Fancy Title",
+//                                                   updateMessage: "New message goes here!",
+//                                                   updateButtonMessage: "Update Now, Plz!?",
+//                                                   nextTimeButtonMessage: "OK, next time it is!",
+//                                                   skipVersionButtonMessage: "Please don't push skip, please don't!")
         
         // Optional - Defaults to .Option
 //        siren.alertType = .option // or .force, .skip, .none

--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -35,7 +35,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 //        siren.appName = "Test App Name"
 
         // Optional - Change the various UIAlertController and UIAlertAction messaging. One or more values can be changes. If only a subset of values are changed, the defaults with which Siren comes with will be used.
-//        siren.alertMessaging = SirenAlertMessaging(updateTitle: "New Fancy Title", updateMessage: "O M G!", updateButtonMessage: "Update Now, Plz!?")
+        siren.alertMessaging = SirenAlertMessaging(updateTitle: "New Fancy Title",
+                                                   updateMessage: "New message goes here!",
+                                                   updateButtonMessage: "Update Now, Plz!?",
+                                                   nextTimeButtonMessage: "OK, next time it is!",
+                                                   skipVersionButtonMessage: "Please don't push skip, please don't!")
         
         // Optional - Defaults to .Option
 //        siren.alertType = .option // or .force, .skip, .none

--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -34,6 +34,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Optional - Change the name of your app. Useful if you have a long app name and want to display a shortened version in the update dialog (e.g., the UIAlertController).
 //        siren.appName = "Test App Name"
 
+        // Optional - Change the various UIAlertController and UIAlertAction messaging. One or more values can be changes. If only a subset of values are changed, the defaults with which Siren comes with will be used.
+//        siren.alertMessaging = SirenAlertMessaging(updateTitle: "New Fancy Title", updateButtonMessage: "Update Now, Plz!?")
+        
         // Optional - Defaults to .Option
 //        siren.alertType = .option // or .force, .skip, .none
 

--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -35,7 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 //        siren.appName = "Test App Name"
 
         // Optional - Change the various UIAlertController and UIAlertAction messaging. One or more values can be changes. If only a subset of values are changed, the defaults with which Siren comes with will be used.
-//        siren.alertMessaging = SirenAlertMessaging(updateTitle: "New Fancy Title", updateButtonMessage: "Update Now, Plz!?")
+//        siren.alertMessaging = SirenAlertMessaging(updateTitle: "New Fancy Title", updateMessage: "O M G!", updateButtonMessage: "Update Now, Plz!?")
         
         // Optional - Defaults to .Option
 //        siren.alertType = .option // or .force, .skip, .none

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -74,7 +74,7 @@ public final class Siren: NSObject {
 
     /// Overrides all the Strings to which Siren defaults.
     /// Defaults to the values defined in `SirenAlertMessaging.Keys`
-    public lazy var alertMessaging = SirenAlertMessaging()
+    public var alertMessaging = SirenAlertMessaging()
 
     /// The region or country of an App Store in which your app is available.
     /// By default, all version checks are performed against the US App Store.

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -73,7 +73,7 @@ public final class Siren: NSObject {
     public lazy var appName = Bundle.bestMatchingAppName()
 
     /// Overrides all the Strings to which Siren defaults.
-    /// Defaults to the values defined in `SirenAlertMessaging.Keys`
+    /// Defaults to the values defined in `SirenAlertMessaging.Constants`
     public var alertMessaging = SirenAlertMessaging()
 
     /// The region or country of an App Store in which your app is available.

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -72,6 +72,10 @@ public final class Siren: NSObject {
     /// By default, it's set to the name of the app that's stored in your plist.
     public lazy var appName = Bundle.bestMatchingAppName()
 
+    /// Overrides all the Strings to which Siren defaults.
+    /// Defaults to the values defined in `SirenAlertMessaging.Keys`
+    public lazy var alertMessaging = SirenAlertMessaging()
+
     /// The region or country of an App Store in which your app is available.
     /// By default, all version checks are performed against the US App Store.
     /// If your app is not available in the US App Store, set it to the identifier of at least one App Store within which it is available.
@@ -279,7 +283,8 @@ private extension Siren {
     func showAlert() {
         storeVersionCheckDate()
 
-        let updateAvailableMessage = Bundle.localizedString(forKey: "Update Available", forceLanguageLocalization: forceLanguageLocalization)
+        let updateAvailableMessage = Bundle.localizedString(forKey: alertMessaging.updateTitle, forceLanguageLocalization: forceLanguageLocalization)
+
         let newVersionMessage = localizedNewVersionMessage()
 
         let alertController = UIAlertController(title: updateAvailableMessage, message: newVersionMessage, preferredStyle: .alert)
@@ -387,7 +392,7 @@ private extension Siren {
 
 private extension Siren {
     func localizedNewVersionMessage() -> String {
-        let newVersionMessageToLocalize = "A new version of %@ is available. Please update to version %@ now."
+        let newVersionMessageToLocalize = alertMessaging.updateMessage
         let newVersionMessage = Bundle.localizedString(forKey: newVersionMessageToLocalize, forceLanguageLocalization: forceLanguageLocalization)
 
         guard let currentAppStoreVersion = currentAppStoreVersion else {
@@ -398,15 +403,15 @@ private extension Siren {
     }
 
     func localizedUpdateButtonTitle() -> String {
-        return Bundle.localizedString(forKey: "Update", forceLanguageLocalization: forceLanguageLocalization)
+        return Bundle.localizedString(forKey: alertMessaging.updateButtonMessage, forceLanguageLocalization: forceLanguageLocalization)
     }
 
     func localizedNextTimeButtonTitle() -> String {
-        return Bundle.localizedString(forKey: "Next time", forceLanguageLocalization: forceLanguageLocalization)
+        return Bundle.localizedString(forKey: alertMessaging.nextTimeButtonMessage, forceLanguageLocalization: forceLanguageLocalization)
     }
 
     func localizedSkipButtonTitle() -> String {
-        return Bundle.localizedString(forKey: "Skip this version", forceLanguageLocalization: forceLanguageLocalization)
+        return Bundle.localizedString(forKey: alertMessaging.skipVersionButtonMessage, forceLanguageLocalization: forceLanguageLocalization)
     }
 }
 

--- a/Sources/SirenAlertMessaging.swift
+++ b/Sources/SirenAlertMessaging.swift
@@ -1,0 +1,54 @@
+//
+//  SirenAlertMessaging.swift
+//  Siren
+//
+//  Created by Arthur Sabintsev on 12/6/17.
+//  Copyright © 2017 Sabintsev iOS Projects. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Siren Alert Messaging Customization
+
+/// Allows the overriding of all the Strings to which Siren defaults
+///
+/// - Warning: Overriding any of these keys will result in the loss of the built-in  internationalization that Siren provides.
+///
+/// As SirenAlertMessaging is a Struct, one _or_ more keys can be modified. Overriding only one string will result in the other keys retaining their default (and internationalizable) values.
+public struct SirenAlertMessaging {
+
+    public struct Keys {
+        public static let nextTime = "Next time"
+        public static let skipVersion = "Skip this version"
+        public static let updateMessage = "A new version of %@ is available. Please update to version %@ now."
+        public static let updateTitle = "Update Available"
+        public static let updateNow = "Update"
+    }
+
+    let nextTimeButtonMessage: String
+    let skipVersionButtonMessage: String
+    let updateButtonMessage: String
+    let updateMessage: String
+    let updateTitle: String
+    
+    /// The public initializer
+    ///
+    /// - Parameters:
+    ///   - title: The title field of the `UIAlertController`.
+    ///   - message: The `message` field of the `UIAlertController`.
+    ///   - updateButtonMessage: The `title` field of the Update Button `UIAlertAction`.
+    ///   - nextTimeButtonMessage: The `title` field of the Next Time Button `UIAlertAction`.
+    ///   - skipVersionButtonMessage: The `title` field of the Skip Button `UIAlertAction`.
+    public init(updateTitle title: String = Keys.updateTitle,
+                updateMessage message: String = Keys.updateMessage,
+                updateButtonMessage: String = Keys.updateNow,
+                nextTimeButtonMessage: String = Keys.nextTime,
+                skipVersionButtonMessage: String = Keys.skipVersion) {
+        self.updateTitle = title
+        self.nextTimeButtonMessage = nextTimeButtonMessage
+        self.updateButtonMessage = updateButtonMessage
+        self.updateMessage = message
+        self.skipVersionButtonMessage = skipVersionButtonMessage
+    }
+
+}

--- a/Sources/SirenAlertMessaging.swift
+++ b/Sources/SirenAlertMessaging.swift
@@ -17,7 +17,7 @@ import Foundation
 /// As SirenAlertMessaging is a Struct, one _or_ more keys can be modified. Overriding only one string will result in the other keys retaining their default (and internationalizable) values.
 public struct SirenAlertMessaging {
 
-    public struct Keys {
+    public struct Constants {
         public static let nextTime = "Next time"
         public static let skipVersion = "Skip this version"
         public static let updateMessage = "A new version of %@ is available. Please update to version %@ now."
@@ -39,11 +39,11 @@ public struct SirenAlertMessaging {
     ///   - updateButtonMessage: The `title` field of the Update Button `UIAlertAction`.
     ///   - nextTimeButtonMessage: The `title` field of the Next Time Button `UIAlertAction`.
     ///   - skipVersionButtonMessage: The `title` field of the Skip Button `UIAlertAction`.
-    public init(updateTitle title: String = Keys.updateTitle,
-                updateMessage message: String = Keys.updateMessage,
-                updateButtonMessage: String = Keys.updateNow,
-                nextTimeButtonMessage: String = Keys.nextTime,
-                skipVersionButtonMessage: String = Keys.skipVersion) {
+    public init(updateTitle title: String = Constants.updateTitle,
+                updateMessage message: String = Constants.updateMessage,
+                updateButtonMessage: String = Constants.updateNow,
+                nextTimeButtonMessage: String = Constants.nextTime,
+                skipVersionButtonMessage: String = Constants.skipVersion) {
         self.updateTitle = title
         self.nextTimeButtonMessage = nextTimeButtonMessage
         self.updateButtonMessage = updateButtonMessage

--- a/Sources/SirenAlertMessaging.swift
+++ b/Sources/SirenAlertMessaging.swift
@@ -30,7 +30,7 @@ public struct SirenAlertMessaging {
     let updateButtonMessage: String
     let updateMessage: String
     let updateTitle: String
-    
+
     /// The public initializer
     ///
     /// - Parameters:

--- a/Sources/SirenAlertMessaging.swift
+++ b/Sources/SirenAlertMessaging.swift
@@ -10,9 +10,9 @@ import Foundation
 
 // MARK: - Siren Alert Messaging Customization
 
-/// Allows the overriding of all the Strings to which Siren defaults
+/// Allows the overriding of all the `UIAlertController` and `UIActionSheet` Strings to which Siren defaults.
 ///
-/// - Warning: Overriding any of these keys will result in the loss of the built-in  internationalization that Siren provides.
+/// - Warning: Overriding any of these keys will result in the loss of the built-in internationalization that Siren provides.
 ///
 /// As SirenAlertMessaging is a Struct, one _or_ more keys can be modified. Overriding only one string will result in the other keys retaining their default (and internationalizable) values.
 public struct SirenAlertMessaging {


### PR DESCRIPTION
This PR adds the `SirenAlertMessaging` struct, which allows for custom overriding of messaging in UIAlertController update modal.

Example usage:

```swift
// Optional - Change the various UIAlertController and UIAlertAction messaging. 
// One or more values can be changes. 
// If only a subset of values are changed, the defaults with which Siren comes with will be used.
SirenAlertMessaging(updateTitle: "New Fancy Title", 
                    updateMessage: "O M G!", 
                    updateButtonMessage: "Update Now, Plz!?")
```

<img width="545" alt="screen shot 2017-12-07 at 10 08 52 am" src="https://user-images.githubusercontent.com/854860/33722038-d0632c40-db36-11e7-8632-d84e942c525c.png">
