### PR TITLE
Check if the return data contains any results

### DIFF
--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -188,6 +188,12 @@ private extension Siren {
             do {
                 let decoder = JSONDecoder()
                 let decodedData = try decoder.decode(SirenLookupModel.self, from: data)
+                
+                // Check if results are not empty
+                if decodedData.results.isEmpty {
+                    postError(.appStoreDataRetrievalNoResults)
+                    return
+                }
 
                 DispatchQueue.main.async { [unowned self] in
                     self.printMessage("Decoded JSON results: \(decodedData)")

--- a/Sources/SirenError.swift
+++ b/Sources/SirenError.swift
@@ -16,6 +16,7 @@ public struct SirenError: LocalizedError {
         case appStoreAppIDFailure
         case appStoreDataRetrievalFailure(underlyingError: Error?)
         case appStoreJSONParsingFailure(underlyingError: Error)
+        case appStoreDataRetrievalNoResults
         case appStoreOSVersionNumberFailure
         case appStoreOSVersionUnsupported
         case appStoreVersionArrayFailure
@@ -31,6 +32,8 @@ public struct SirenError: LocalizedError {
                 return "Error retrieving App Store data as an error was returned\nAlso, the following system level error was returned: \(error)"
             case .appStoreDataRetrievalFailure(.none):
                 return "Error retrieving App Store data as an error was returned."
+            case .appStoreDataRetrievalNoResults:
+                return "Error retrieving App Store data as there were not any results returned. Is your app available in the US? If not, change the countryCode."
             case .appStoreJSONParsingFailure(let error):
                 return "Error parsing App Store JSON data.\nAlso, the following system level error was returned: \(error)"
             case .appStoreOSVersionNumberFailure:


### PR DESCRIPTION
My app was not available in the US and I did not get any error messages, but the alert still did not show up. I made a request to the iTunes Connect API to see the results and realised that there were not any results returned. I added an error check for such cases to hopefully save others some debugging time. 

Maybe the country code should be mentioned in the ReadMe also.

Nice work btw, love Siren!