### PR TITLE
Changed pt-BR text to be less aggressive.

### DIFF
--- a/Sources/Siren.bundle/pt.lproj/SirenLocalizable.strings
+++ b/Sources/Siren.bundle/pt.lproj/SirenLocalizable.strings
@@ -1,5 +1,5 @@
 ﻿/* Update alert message: A new version of {APP NAME} is available. Please update to version {NEW VERSION} now.*/
-"A new version of %@ is available. Please update to version %@ now."="Uma nova versão do %@ está disponível. Por favor atualize para a versão %@ agora.";
+"A new version of %@ is available. Please update to version %@ now."="Uma nova versão do %@ está disponível. Por favor atualize para a versão %@.";
 
 /* Update alert title */
 "Update Available"="Atualização disponível";


### PR DESCRIPTION
I don't know if you guys accept the kind of PR. But we think after seeing in our app that the default message in Portuguese is a little "passive-aggressive". Because of the "NOW" "agora" in the end.

We changed the message locally, but it would be nice to see if there are anyone from brasil using that think this world could be removed too.

Thanks!