### PR TITLE
SirenDelegate Enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: objective-c
 osx_image: xcode9.3
 
+notifications:
+  email: false
 env:
   - LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8
 before_install:

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If you would like to set a different type of alert for revision, patch, minor, a
 Six delegate methods allow you to handle or track the user's behavior. Each method has a default, empty implementation, effectively making each of these methods optional.
 
 ```	swift
-public protocol SirenDelegate: class {
+public protocol SirenDelegate: NSObjectProtocol {
 	/// Siren performed version check and did not display alert.
 	func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Notify users when a new version of your app is available and prompt them to upgrade.
 
-![Travis CI Status](https://travis-ci.org/ArtSabintsev/Siren.svg?branch=master) 
+![Travis CI Status](https://travis-ci.org/ArtSabintsev/Siren.svg?branch=master)
 
 ![Swift Support](https://img.shields.io/badge/Swift-2.3%2C%203.1%2C%203.2%2C%204.1-orange.svg) ![Documentation](https://github.com/ArtSabintsev/Siren/blob/master/docs/badge.svg)
 
@@ -215,23 +215,38 @@ Six delegate methods allow you to handle or track the user's behavior. Each meth
 
 ```	swift
 public protocol SirenDelegate: class {
-    // User presented with update dialog
-    func sirenDidShowUpdateDialog(alertType: Siren.AlertType)
+	/// Siren performed version check and did not display alert.
+	func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType)
 
-    // User did click on button that launched App Store.app
-    func sirenUserDidLaunchAppStore()
+	/// Siren failed to perform version check.
+	///
+	/// - Note:
+	///     Depending on the reason for failure,
+	///     a system-level error may be returned.
+	func sirenDidFailVersionCheck(error: Error)
 
-    // User did click on button that skips version update
-    func sirenUserDidSkipVersion()
+	/// User presented with update dialog.
+	func sirenDidShowUpdateDialog(alertType: Siren.AlertType)
 
-    // User did click on button that cancels update dialog
-    func sirenUserDidCancel()                                 
-    
-    // Siren failed to perform version check (may return system-level error)
-    func sirenDidFailVersionCheck(error: Error)                
+	/// Siren performed a version check and latest version is installed.
+	func sirenLatestVersionInstalled()
 
-    // Siren performed version check and did not display alert
-    func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType)
+	/// Provides the decoded JSON information from a successful version check call.
+	///
+	/// - SeeAlso:
+	///     SirenLookupModel.swift
+	///
+	/// - Parameter lookupModel: The `Decodable` model representing the JSON results from the iTunes Lookup API.
+	func sirenNetworkCallDidReturnWithNewVersionInformation(lookupModel: SirenLookupModel)
+
+	/// User did click on button that cancels update dialog.
+	func sirenUserDidCancel()
+
+	/// User did click on button that launched "App Store.app".
+	func sirenUserDidLaunchAppStore()
+
+	/// User did click on button that skips version update.
+	func sirenUserDidSkipVersion()
 }
 ```
 

--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -102,6 +102,10 @@ extension AppDelegate: SirenDelegate
         print(#function, "Latest version of app is installed")
     }
 
+    func sirenNetworkCallDidReturnWithNewVersionInformation(lookupModel: SirenLookupModel) {
+        print(#function, "\(lookupModel)")
+    }
+
     // This delegate method is only hit when alertType is initialized to .none
     func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType) {
         print(#function, "\(message).\nRelease type: \(updateType.rawValue.capitalized)")

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -194,6 +194,8 @@ private extension Siren {
                 DispatchQueue.main.async { [weak self] in
                     self?.printMessage("Decoded JSON results: \(decodedData)")
 
+                    self?.delegate?.sirenNetworkCallDidReturnWithNewVersionInformation(lookupModel: decodedData)
+
                     // Process Results (e.g., extract current version that is available on the AppStore)
                     self?.processVersionCheck(with: decodedData)
                 }

--- a/Sources/SirenDelegate.swift
+++ b/Sources/SirenDelegate.swift
@@ -31,17 +31,8 @@ public enum UpdateType: String {
 
 /// Delegate that handles all codepaths for Siren upon version check completion.
 public protocol SirenDelegate: NSObjectProtocol {
-    /// User presented with update dialog.
-    func sirenDidShowUpdateDialog(alertType: Siren.AlertType)
-
-    /// User did click on button that launched "App Store.app".
-    func sirenUserDidLaunchAppStore()
-
-    /// User did click on button that skips version update.
-    func sirenUserDidSkipVersion()
-
-    /// User did click on button that cancels update dialog.
-    func sirenUserDidCancel()
+    /// Siren performed version check and did not display alert.
+    func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType)
 
     /// Siren failed to perform version check.
     ///
@@ -50,30 +41,35 @@ public protocol SirenDelegate: NSObjectProtocol {
     ///     a system-level error may be returned.
     func sirenDidFailVersionCheck(error: Error)
 
-    /// Siren performed version check and did not display alert.
-    func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType)
+    /// User presented with update dialog.
+    func sirenDidShowUpdateDialog(alertType: Siren.AlertType)
 
-    /// Siren performed version check and latest version is installed.
+    /// Siren performed a version check and latest version is installed.
     func sirenLatestVersionInstalled()
+
+    /// Provides the decoded JSON information from a successful version check call.
+    ///
+    /// - SeeAlso:
+    ///     SirenLookupModel.swift
+    ///
+    /// - Parameter lookupModel: The `Decodable` model representing the JSON results from the iTunes Lookup API.
+    func sirenNetworkCallDidReturnWithNewVersionInformation(lookupModel: SirenLookupModel)
+
+    /// User did click on button that cancels update dialog.
+    func sirenUserDidCancel()
+
+    /// User did click on button that launched "App Store.app".
+    func sirenUserDidLaunchAppStore()
+
+    /// User did click on button that skips version update.
+    func sirenUserDidSkipVersion()
 }
 
 // MARK: - SirenDelegate Protocol Extension
 
 public extension SirenDelegate {
 
-    func sirenDidShowUpdateDialog(alertType: Siren.AlertType) {
-        printMessage()
-    }
-
-    func sirenUserDidLaunchAppStore() {
-        printMessage()
-    }
-
-    func sirenUserDidSkipVersion() {
-        printMessage()
-    }
-
-    func sirenUserDidCancel() {
+    func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType) {
         printMessage()
     }
 
@@ -81,11 +77,27 @@ public extension SirenDelegate {
         printMessage()
     }
 
-    func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType) {
+    func sirenDidShowUpdateDialog(alertType: Siren.AlertType) {
         printMessage()
     }
 
     func sirenLatestVersionInstalled() {
+        printMessage()
+    }
+
+    func sirenUserDidCancel() {
+        printMessage()
+    }
+
+    func sirenUserDidLaunchAppStore() {
+        printMessage()
+    }
+
+    func sirenNetworkCallDidReturnWithNewVersionInformation(lookupModel: SirenLookupModel) {
+        printMessage()
+    }
+
+    func sirenUserDidSkipVersion() {
         printMessage()
     }
 

--- a/Sources/SirenDelegate.swift
+++ b/Sources/SirenDelegate.swift
@@ -49,9 +49,6 @@ public protocol SirenDelegate: NSObjectProtocol {
 
     /// Provides the decoded JSON information from a successful version check call.
     ///
-    /// - SeeAlso:
-    ///     SirenLookupModel.swift
-    ///
     /// - Parameter lookupModel: The `Decodable` model representing the JSON results from the iTunes Lookup API.
     func sirenNetworkCallDidReturnWithNewVersionInformation(lookupModel: SirenLookupModel)
 

--- a/Sources/SirenLookupModel.swift
+++ b/Sources/SirenLookupModel.swift
@@ -10,14 +10,14 @@ import Foundation
 
 // MARK: - Model representing a selection of results from the iTunes Lookup API
 
-struct SirenLookupModel: Decodable {
+public struct SirenLookupModel: Decodable {
     private enum CodingKeys: String, CodingKey {
         case results
     }
 
-    let results: [Results]
+    public let results: [Results]
 
-    struct Results: Decodable {
+    public struct Results: Decodable {
         private enum CodingKeys: String, CodingKey {
             case appID = "trackId"
             case currentVersionReleaseDate
@@ -26,10 +26,10 @@ struct SirenLookupModel: Decodable {
             case version
         }
 
-        let appID: Int
-        let currentVersionReleaseDate: String
-        let minimumOSVersion: String
-        let releaseNotes: String?
-        let version: String
+        public let appID: Int
+        public let currentVersionReleaseDate: String
+        public let minimumOSVersion: String
+        public let releaseNotes: String?
+        public let version: String
     }
 }


### PR DESCRIPTION
Implementing the request #206 enabled the `SirenLookpModel` to parse out the release notes information. Unfortunately, that information was not obtainable by consumers of Siren. This PR exposes a new delegate method that allows consumers to make use of all the information parsed out of a successful JSON call. 

```swift
sirenNetworkCallDidReturnWithNewVersionInformation(lookupModel: SirenLookupModel)
``` 