### PR TITLE
Localized title

### DIFF
--- a/SirenExample/SirenExample/AppDelegate.swift
+++ b/SirenExample/SirenExample/AppDelegate.swift
@@ -107,7 +107,7 @@ extension AppDelegate: SirenDelegate
     }
 
     // This delegate method is only hit when alertType is initialized to .none
-    func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType) {
+    func sirenDidDetectNewVersionWithoutAlert(title: String, message: String, updateType: UpdateType) {
         print(#function, "\(message).\nRelease type: \(updateType.rawValue.capitalized)")
     }
 }

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -30,7 +30,7 @@ public final class Siren: NSObject {
     /// - sirenUserDidCancel()
     ///
     /// When a new version has been detected, and you would like to present a localized message in a custom UI. use this delegate method:
-    /// - sirenDidDetectNewVersionWithoutAlert(message: String)
+    /// - sirenDidDetectNewVersionWithoutAlert(title: String, message: String)
     public weak var delegate: SirenDelegate?
 
     /// The debug flag, which is disabled by default.
@@ -288,6 +288,7 @@ private extension Siren {
 
         let updateAvailableMessage = Bundle.localizedString(forKey: alertMessaging.updateTitle, forceLanguageLocalization: forceLanguageLocalization)
 
+        let updateTitle = localizedUpdateTitle()
         let newVersionMessage = localizedNewVersionMessage()
 
         let alertController = UIAlertController(title: updateAvailableMessage, message: newVersionMessage, preferredStyle: .alert)
@@ -307,7 +308,7 @@ private extension Siren {
             alertController.addAction(updateAlertAction())
             alertController.addAction(skipAlertAction())
         case .none:
-            delegate?.sirenDidDetectNewVersionWithoutAlert(message: newVersionMessage, updateType: updateType)
+            delegate?.sirenDidDetectNewVersionWithoutAlert(title: updateTitle, message: newVersionMessage, updateType: updateType)
         }
 
         if alertType != .none && !alertViewIsVisible {

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -405,6 +405,11 @@ private extension Siren {
 // MARK: - Helpers (Localization)
 
 private extension Siren {
+    func localizedUpdateTitle() -> String {
+        let updateTitleToLocalize = alertMessaging.updateTitle
+        return Bundle.localizedString(forKey: updateTitleToLocalize, forceLanguageLocalization: forceLanguageLocalization)
+    }
+    
     func localizedNewVersionMessage() -> String {
         let newVersionMessageToLocalize = alertMessaging.updateMessage
         let newVersionMessage = Bundle.localizedString(forKey: newVersionMessageToLocalize, forceLanguageLocalization: forceLanguageLocalization)

--- a/Sources/SirenDelegate.swift
+++ b/Sources/SirenDelegate.swift
@@ -32,7 +32,7 @@ public enum UpdateType: String {
 /// Delegate that handles all codepaths for Siren upon version check completion.
 public protocol SirenDelegate: NSObjectProtocol {
     /// Siren performed version check and did not display alert.
-    func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType)
+    func sirenDidDetectNewVersionWithoutAlert(title: String, message: String, updateType: UpdateType)
 
     /// Siren failed to perform version check.
     ///
@@ -66,7 +66,7 @@ public protocol SirenDelegate: NSObjectProtocol {
 
 public extension SirenDelegate {
 
-    func sirenDidDetectNewVersionWithoutAlert(message: String, updateType: UpdateType) {
+    func sirenDidDetectNewVersionWithoutAlert(title: String, message: String, updateType: UpdateType) {
         printMessage()
     }
 


### PR DESCRIPTION
Expose localized title in `sirenDidDetectNewVersionWithoutAlert` delegate method in order to allow to reuse it along with localized message.
