### PR TITLE
Use method introduced in iOS 10 for opening URLs with UIApplication

### DIFF
--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -154,7 +154,11 @@ public final class Siren: NSObject {
         }
 
         DispatchQueue.main.async {
-            UIApplication.shared.openURL(url)
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            } else {
+                UIApplication.shared.openURL(url)
+            }
         }
     }
 


### PR DESCRIPTION
UIApplication.openUrl(_:) is deprecated in iOS 10. Adjusting to prevent compiler warning when using a deployment target of iOS 10 or later.