### PR TITLE
Update Siren.swift

### DIFF
--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -242,6 +242,7 @@ private extension Siren {
         guard daysSinceRelease >= showAlertAfterCurrentVersionHasBeenReleasedForDays else {
             let message = "Your app has been released for \(daysSinceRelease) days, but Siren cannot prompt the user until \(showAlertAfterCurrentVersionHasBeenReleasedForDays) days have passed."
             self.printMessage(message)
+            delegate?.sirenDidDetectNewVersionWithoutAlert(title: localizedUpdateTitle(), message: localizedNewVersionMessage(), updateType: updateType)
             return
         }
 


### PR DESCRIPTION
Trigger delegate method `sirenDidDetectNewVersionWithoutAlert` if `daysSinceRelease` is not fulfilled to show alert.