### PR TITLE
Force update based on minimum version set by user

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -63,6 +63,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Optional (Only do this if you don't call checkVersion in didBecomeActive)
 //        siren.checkVersion(checkType: .immediately)
+        
+        //Force Version Udpate
+        siren.majorUpdateAlertType = .skip
+        siren.minorUpdateAlertType = .skip
+        siren.patchUpdateAlertType = .skip
+        siren.revisionUpdateAlertType = .skip
+        siren.showAlertAfterCurrentVersionHasBeenReleasedForDays = 3
+        siren.minimumAppVersionToForceUserToUpdate = "0.1.0"
+        siren.checkVersion(checkType: .immediately)
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -92,6 +92,12 @@ public final class Siren: NSObject {
     /// Defaults to 1 day to avoid an issue where Apple updates the JSON faster than the app binary propogates to the App Store.
     public var showAlertAfterCurrentVersionHasBeenReleasedForDays: Int = 1
 
+    /// When this is set, it will show a force update alert to user by bypassing alertType, storedSkippedVersion and showAlertAfterCurrentVersionHasBeenReleasedForDays settings
+    /// checkVersion(checkType: .immediately) has to be called after setting it in order to be able to show force alert message immediately
+    /// otherwise old settings will be followed i.e. check daily or weekly if set
+    /// In processVersionCheck() method it will check if the version set by user here is greater than the current installed version in order to show force update alert
+    public var minimumAppVersionToForceUserToUpdate: String?
+    
     /// The current version of your app that is available for download on the App Store
     public internal(set) var currentAppStoreVersion: String?
 
@@ -234,6 +240,12 @@ private extension Siren {
             return
         }
 
+        if isUserSetForcedVersionNewer() == true {
+            alertType = .force
+            showAlert()
+            return
+        }
+        
         guard let currentVersionReleaseDate = model.results.first?.currentVersionReleaseDate,
             let daysSinceRelease = Date.days(since: currentVersionReleaseDate) else {
             return

--- a/Sources/Utilities/SirenHelpers.swift
+++ b/Sources/Utilities/SirenHelpers.swift
@@ -12,16 +12,21 @@ import Foundation
 
 extension Siren {
     func isAppStoreVersionNewer() -> Bool {
-        var newVersionExists = false
-
         if let currentInstalledVersion = currentInstalledVersion,
             let currentAppStoreVersion = currentAppStoreVersion,
             (currentInstalledVersion.compare(currentAppStoreVersion, options: .numeric) == .orderedAscending) {
-
-            newVersionExists = true
+            return true
         }
-
-        return newVersionExists
+        return false
+    }
+    
+    func isUserSetForcedVersionNewer() -> Bool {
+        if let currentInstalledVersion = currentInstalledVersion,
+            let targetedForcedVersion = minimumAppVersionToForceUserToUpdate,
+            (currentInstalledVersion.compare(targetedForcedVersion, options: .numeric) == .orderedAscending) {
+            return true
+        }
+        return false
     }
 
     func storeVersionCheckDate() {


### PR DESCRIPTION
@ArtSabintsev I made changes for Siren as we discussed. I worked on @getaaron suggestion to write a better interface than to just reset the skip version status.
Please review it and let me know if I made any mistakes, I tested it and its working good. I hope I didn't miss nay conditions.
There was one scenario, where user might want to show custom alert to user and not use the default one, but I didn't handle the case. May be someone can do it if required in future.