### PR TITLE
Add an enum `SirenEitherType` to adjust the type of value for key "tr…

### DIFF
--- a/Sources/Models/SirenEitherType.swift
+++ b/Sources/Models/SirenEitherType.swift
@@ -1,0 +1,40 @@
+//
+//  SirenEitherType.swift
+//  Siren
+//
+//  Created by Daniel Lin on 2018/10/26.
+//
+
+import Foundation
+
+public enum SirenEitherType<L, R> {
+    case left(L)
+    case right(R)
+}
+
+extension SirenEitherType: Decodable where L: Decodable, R: Decodable {
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let left = try? container.decode(L.self) {
+            self = .left(left)
+        } else if let right = try? container.decode(R.self) {
+            self = .right(right)
+        } else {
+            throw DecodingError.typeMismatch(SirenEitherType<L, R>.self, .init(codingPath: decoder.codingPath, debugDescription: "Type expected either `\(L.self)` or `\(R.self)`"))
+        }
+    }
+}
+
+extension SirenEitherType: Encodable where L: Encodable, R: Encodable {
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .left(left):
+            try container.encode(left)
+        case let .right(right):
+            try container.encode(right)
+        }
+    }
+}

--- a/Sources/Models/SirenLookupModel.swift
+++ b/Sources/Models/SirenLookupModel.swift
@@ -30,7 +30,7 @@ public struct SirenLookupModel: Decodable {
         }
 
         /// The app's App ID.
-        public let appID: String
+        public let appID: SirenEitherType<String, Int>
 
         /// The release date for the latest verison of the app.
         public let currentVersionReleaseDate: String

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -101,7 +101,7 @@ public final class Siren: NSObject {
     /// The last Date that a version check was performed.
     var lastVersionCheckPerformedOnDate: Date?
 
-    fileprivate var appID: String?
+    fileprivate var appID: SirenEitherType<String, Int>?
     fileprivate lazy var alertViewIsVisible: Bool = false
 
     /// Type of the available update


### PR DESCRIPTION
…ackId" that sometimes would be either `String` or `Int`.

> [Siren] Error parsing App Store JSON data.
Also, the following system level error was returned: typeMismatch(Swift.String, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "results", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "trackId", intValue: nil)], debugDescription: "Expected to decode String but found a number instead.", underlyingError: nil))

Recently I received the error message above in sometimes and found that the type of "trackId" from JSON response would be either `String` or `Int` caused this issue. So I add a new enum `SirenEitherType` to adjust for the different type(`String` or `Int`) of `appID` in `SirenLookupModel`.