### PR TITLE
Removed print statement from UserDefaults getter

### DIFF
--- a/Sources/Extensions/SirenUserDefaultsExtension.swift
+++ b/Sources/Extensions/SirenUserDefaultsExtension.swift
@@ -26,7 +26,6 @@ private enum SirenKeys: String {
 extension UserDefaults {
     static var shouldPerformVersionCheckOnSubsequentLaunch: Bool {
         get {
-            print(#function, standard.bool(forKey: SirenKeys.PerformVersionCheckOnSubsequentLaunch.rawValue))
             return standard.bool(forKey: SirenKeys.PerformVersionCheckOnSubsequentLaunch.rawValue)
         } set {
             standard.set(newValue, forKey: SirenKeys.PerformVersionCheckOnSubsequentLaunch.rawValue)


### PR DESCRIPTION
Had this being printed to console for a few builds now: `shouldPerformVersionCheckOnSubsequentLaunch false`. It happens whenever I call `siren.checkVersion(checkType: .daily)`.

It's somewhat annoying as it's the only thing that gets output to the console, and it doesn't mean anything to me pretty much. I assume it was left in there as some kind of debug logging, kept waiting for someone to get rid of it, so here a PR. :)