### PR TITLE
add `hinting` static rules configuration

### DIFF
--- a/Sources/Models/Rules.swift
+++ b/Sources/Models/Rules.swift
@@ -27,15 +27,15 @@ public struct Rules {
         self.frequency = frequency
         self.alertType = alertType
     }
+    
+    /// Performs a version check immediately and forces the user to update the app.
+    public static var critical: Rules {
+        return Rules(promptFrequency: .immediately, forAlertType: .force)
+    }
 
     /// Performs a version check immediately, but allows the user to skip updating the app until the next time the app becomes active.
     public static var annoying: Rules {
         return Rules(promptFrequency: .immediately, forAlertType: .option)
-    }
-
-    /// Performs a version check immediately and forces the user to update the app.
-    public static var critical: Rules {
-        return Rules(promptFrequency: .immediately, forAlertType: .force)
     }
 
     /// Performs a version check once a day, but allows the user to skip updating the app until
@@ -49,6 +49,11 @@ public struct Rules {
     /// Performs a version check daily, but allows the user to skip updating the app until the next time the app becomes active.
     public static var persistent: Rules {
         return Rules(promptFrequency: .daily, forAlertType: .option)
+    }
+    
+    /// Performs a version check weekly, but allows the user to skip updating the app until the next time the app becomes active.
+    public static var hinting: Rules {
+        return Rules(promptFrequency: .weekly, forAlertType: .option)
     }
 
     /// Performs a version check weekly, but allows the user to skip updating the app until


### PR DESCRIPTION
Kinda a small change that doesn't serve much purpose considering that users can always to a manual configuration, BUT, I felt like it should be provided as with the understanding that the combination left out are the ones that are counter intuitive in some way.

(weekly / skip):  relaxed
(weekly / option): This is the rules configuration being added. Not as heavy handed as persistent, but not as relaxed as .... relaxed.  A casual weekly hint that something better is available. 
(weekly / force): seems counter intuitive to have force with anything other than immediate

(daily / option): persistent
(daily / skip): the default behavior
(daily / force): seems counter intuitive to have force with anything other than immediate

(immediately / option): annoying 
(immediately / skip): seems counter intuitive to need this combination as why would you want to combine immediate with ability for a user to skip it all together.
(immediately / force): Critical
