### PR TITLE
FIX a conditional statement for the skip action.

### DIFF
--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -172,7 +172,7 @@ private extension Siren {
         if let previouslySkippedVersion = UserDefaults.storedSkippedVersion,
             let currentInstalledVersion = currentInstalledVersion,
             !currentAppStoreVersion.isEmpty,
-            currentAppStoreVersion != previouslySkippedVersion {
+            currentAppStoreVersion == previouslySkippedVersion {
             resultsHandler?(nil, .skipVersionUpdate(installedVersion: currentInstalledVersion, appStoreVersion: currentAppStoreVersion))
                 return
         }


### PR DESCRIPTION
Hey, I updated Siren to the latest version (4.1.1) and took it for a spin. However, I noticed that it seems like the skip action doesn't work despite a user tapped the skip button. I looked into the code and figured out the problem.  

To skip the version, I believe that "previouslySkippedVersion" should be equal to "currentAppStoreVersion". Hope that makes it work correctly. Please take a look when you are available.

Thanks