### PR TITLE
Fix for comparing current version with app store of same version

### DIFF
--- a/Sources/Extensions/BundleExtension.swift
+++ b/Sources/Extensions/BundleExtension.swift
@@ -29,9 +29,12 @@ extension Bundle {
     /// Fetches the current verison of the app.
     ///
     /// - Returns: The current installed version of the app.
-    final class func version() -> String? {
-        return Bundle.main.object(forInfoDictionaryKey: Constants.shortVersionString) as? String
-    }
+    final class func version() -> String {
+        let dictionary = Bundle.main.infoDictionary!
+        let version = dictionary["CFBundleShortVersionString"] as! String
+        let build = dictionary["CFBundleVersion"] as! String
+        return "\(version).\(build)"
+    } 
 
     /// Returns the localized string for a given default string.
     ///


### PR DESCRIPTION
Gets version plus build so that comparison between app store version and local app version are correct. Otherwise the Siren popup is always shown. For example: v1.44.9 (app store) is always greater than local version v1.44 because no build number is included.