### PR TITLE
Fix left-over window bug after dismissing alert

### DIFF
--- a/Sources/Managers/PresentationManager.swift
+++ b/Sources/Managers/PresentationManager.swift
@@ -38,7 +38,7 @@ public struct PresentationManager {
     var alertController: UIAlertController?
 
     /// The `UIWindow` instance that presents the `SirenViewController`.
-    private var updaterWindow: UIWindow {
+    private var updaterWindow: UIWindow = {
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.windowLevel = UIWindow.Level.alert + 1
 
@@ -47,7 +47,7 @@ public struct PresentationManager {
 
         window.rootViewController = viewController
         return window
-    }
+    }()
 
     /// `PresentationManager`'s public initializer.
     ///


### PR DESCRIPTION
Creating the window only once, at the time of access of the updaterWindow.

This should fix the scenario where the window is not removed after skipping the update (https://github.com/ArtSabintsev/Siren/issues/308)

### The Bug:
The `updaterWindow` was accessed five times in different places inside Presentation manager.
On each access it recreated a new window.

On dismissal of the SirenViewController; the last displayed window stayed on screen and was never removed. This blocked all actions on the screen.

### The Fix:
Storing the created window avoids this by ensuring a single window for Siren.