### PR TITLE
Fixed case when system notification is shown when trying to show Siren alert

### DIFF
--- a/Sources/Managers/PresentationManager.swift
+++ b/Sources/Managers/PresentationManager.swift
@@ -133,7 +133,7 @@ extension PresentationManager {
         // If the alertType is .none, an alert will not be presented.
         // If the `updaterWindow` is not hidden, then an alert is already presented.
         // The latter prevents `UIAlertController`'s from appearing on top of each other.
-        if rules.alertType != .none, updaterWindow.isHidden {
+        if rules.alertType != .none, let updaterWindow = updaterWindow, updaterWindow.isHidden {
             alertController?.show(window: updaterWindow)
         } else {
             // This is a safety precaution to avoid multiple windows from presenting on top of each other.
@@ -143,6 +143,7 @@ extension PresentationManager {
 
     /// Removes the `alertController` from memory.
     func cleanUp() {
+        guard let updaterWindow = updaterWindow else { return }
         alertController?.hide(window: updaterWindow)
         alertController?.dismiss(animated: true, completion: nil)
         updaterWindow.resignKey()
@@ -224,10 +225,10 @@ private extension PresentationManager {
 // MARK: - Helpers
 
 private extension PresentationManager {
-    private func createWindow() -> UIWindow {
+    private func createWindow() -> UIWindow? {
         var window = UIWindow()
         if #available(iOS 13.0, *) {
-            guard let windowScene = getFirstForegroundScene() else { return UIWindow() }
+            guard let windowScene = getFirstForegroundScene() else { return nil }
             window = UIWindow(windowScene: windowScene)
         } else {
             window = UIWindow(frame: UIScreen.main.bounds)

--- a/Sources/Managers/PresentationManager.swift
+++ b/Sources/Managers/PresentationManager.swift
@@ -227,8 +227,7 @@ private extension PresentationManager {
     private func createWindow() -> UIWindow {
         var window = UIWindow()
         if #available(iOS 13.0, *) {
-            guard let windowScene = UIApplication.shared.connectedScenes
-                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else { return UIWindow() }
+            guard let windowScene = getFirstForegroundScene() else { return UIWindow() }
             window = UIWindow(windowScene: windowScene)
         } else {
             window = UIWindow(frame: UIScreen.main.bounds)
@@ -241,5 +240,15 @@ private extension PresentationManager {
 
         window.rootViewController = viewController
         return window
+    }
+
+    @available(iOS 13.0, *)
+    private func getFirstForegroundScene() -> UIWindowScene? {
+        let connectedScenes = UIApplication.shared.connectedScenes
+        if let windowActiveScene = connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+            return windowActiveScene
+        } else {
+            return connectedScenes.first(where: { $0.activationState == .foregroundInactive }) as? UIWindowScene
+        }
     }
 }


### PR DESCRIPTION
This change fixes https://github.com/ArtSabintsev/Siren/issues/341 for me. Guard statement was not finding an app Scene because it was in a different state. 