### PR TITLE
Fix Swift PM 5.3 Resource Bundle Migration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,4 +90,4 @@ DEPENDENCIES
   cocoapods
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/Package.swift
+++ b/Package.swift
@@ -3,18 +3,8 @@ import PackageDescription
 
 let package = Package(
     name: "Siren",
-    platforms: [
-        .iOS(.v11), 
-        .tvOS(.v11)
-    ],
-    products: [
-        .library(name: "Siren", targets: ["Siren"])
-    ],
-    targets: [
-        .target(
-            name: "Siren", 
-            path: "Sources", 
-            resources: [.copy("Siren.bundle")])
-    ],
+    platforms: [.iOS(.v11), .tvOS(.v11)],
+    products: [.library(name: "Siren", targets: ["Siren"])],
+    targets: [.target(name: "Siren", path: "Sources", resources: [.copy("Siren.bundle")])],
     swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,15 @@ import PackageDescription
 
 let package = Package(
     name: "Siren",
-    platforms: [.iOS(.v11), .tvOS(.v11)],
-    products: [.library(name: "Siren", targets: ["Siren"])],
-    targets: [.target(name: "Siren", path: "Sources")],
+    platforms: [
+        .iOS(.v11), 
+        .tvOS(.v11)
+    ],
+    products: [
+        .library(name: "Siren", targets: ["Siren"])
+    ],
+    targets: [
+        .target(name: "Siren", path: "Sources", resources: [.process("Siren.bundle")])
+    ],
     swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "Siren", targets: ["Siren"])
     ],
     targets: [
-        .target(name: "Siren", path: "Sources", resources: [.process("Siren.bundle")])
+        .target(name: "Siren", path: "Sources", resources: [.copy("Siren.bundle")])
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,10 @@ let package = Package(
         .library(name: "Siren", targets: ["Siren"])
     ],
     targets: [
-        .target(name: "Siren", path: "Sources", resources: [.copy("Siren.bundle")])
+        .target(
+            name: "Siren", 
+            path: "Sources", 
+            resources: [.copy("Siren.bundle")])
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Sources/Extensions/BundleExtension.swift
+++ b/Sources/Extensions/BundleExtension.swift
@@ -82,6 +82,11 @@ private extension Bundle {
     ///
     /// - Returns: The bundle's path or `nil`.
     final class func sirenBundlePath() -> String? {
+        #if SWIFT_PACKAGE
+        let resourceBundle = Bundle.module
+        return resourceBundle.path(forResource: "\(Siren.self)", ofType: Constants.bundleExtension)
+        #endif
+        
         return Bundle(for: Siren.self).path(forResource: "\(Siren.self)", ofType: Constants.bundleExtension)
     }
 


### PR DESCRIPTION
This PR fixes a longstanding issue around localization for Swift PM users. Since Swift PM 5.3's can now explicitly bring in bundlers, localization should not work with users installing Siren using Swift PM v5.3.

Thanks to #357 for bringing this issue to light.