### PR TITLE
Add tvOS 13 to if available checks in Presentation Manager

### DIFF
--- a/Sources/Managers/APIManager.swift
+++ b/Sources/Managers/APIManager.swift
@@ -114,6 +114,11 @@ extension APIManager {
 
         var items: [URLQueryItem] = [URLQueryItem(name: Constants.bundleID, value: Bundle.main.bundleIdentifier)]
 
+        #if os(tvOS)
+        let tvOSQueryItem = URLQueryItem(name: "entity", value: "tvSoftware")
+        items.append(tvOSQueryItem)
+        #endif
+        
         if let countryCode = country.code {
             let item = URLQueryItem(name: Constants.country, value: countryCode)
             items.append(item)

--- a/Sources/Managers/APIManager.swift
+++ b/Sources/Managers/APIManager.swift
@@ -16,6 +16,10 @@ public struct APIManager {
         static let bundleID = "bundleId"
         /// Constant for the `country` parameter in the iTunes Lookup API request.
         static let country = "country"
+        /// Constant for the `entity` parameter in the iTunes Lookup API reqeust.
+        static let entity = "entity"
+        /// Constant for the `entity` parameter value when performing a tvOS iTunes Lookup API reqeust.
+        static let tvSoftware = "tvSoftware"
     }
 
     /// Return results or errors obtained from performing a version check with Siren.
@@ -115,7 +119,7 @@ extension APIManager {
         var items: [URLQueryItem] = [URLQueryItem(name: Constants.bundleID, value: Bundle.main.bundleIdentifier)]
 
         #if os(tvOS)
-        let tvOSQueryItem = URLQueryItem(name: "entity", value: "tvSoftware")
+        let tvOSQueryItem = URLQueryItem(name: Constants.entity, value: Constants.tvSoftware)
         items.append(tvOSQueryItem)
         #endif
         

--- a/Sources/Managers/PresentationManager.swift
+++ b/Sources/Managers/PresentationManager.swift
@@ -227,7 +227,7 @@ private extension PresentationManager {
 private extension PresentationManager {
     private func createWindow() -> UIWindow? {
         var window = UIWindow()
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.0, tvOS 13.0, *) {
             guard let windowScene = getFirstForegroundScene() else { return nil }
             window = UIWindow(windowScene: windowScene)
         } else {
@@ -243,7 +243,7 @@ private extension PresentationManager {
         return window
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, tvOS 13.0, *)
     private func getFirstForegroundScene() -> UIWindowScene? {
         let connectedScenes = UIApplication.shared.connectedScenes
         if let windowActiveScene = connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {


### PR DESCRIPTION
I'm working on a project that has an iOS as well as a tvOS version of the app. When I tried compiling the project with Siren against our tvOS target, it does not compile, as a result of the if #available checks in the Presentation manager.  tvOS reasonably handles presenting an Alert (albeit as a full-screen overlay) and it works just fine in tvOS. As in iOS, it's difficult to test on a tvOS simulator, but on an actual AppleTV device, it does redirect to the App Store app to download the newest version just like iOS.