### PR TITLE
Update dialog can't appear bug

### DIFF
--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -60,6 +60,9 @@ public final class Siren: NSObject {
     
     /// Prevent can't appear update dialog when user swipe down the notification center screen to the bottom of screen when call Siren.shared.wail as .onForeground
     private var appDidBecomeActiveWorkItem: DispatchWorkItem?
+    
+    /// The time to consider what is it called by notification center screen to bottom
+    private let delayTimeToConsiderCalledByNotificationCenterScreen = 0.02
 
     /// The deinitialization method that clears out all observers,
     deinit {
@@ -288,7 +291,9 @@ private extension Siren {
                             self.appDidBecomeActiveWorkItem = DispatchWorkItem {
                                 self.performVersionCheck()
                             }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02, execute: self.appDidBecomeActiveWorkItem!)
+                            if let appDidBecomeActiveWorkItem = self.appDidBecomeActiveWorkItem {
+                                DispatchQueue.main.asyncAfter(deadline: .now() + self.delayTimeToConsiderCalledByNotificationCenterScreen, execute: appDidBecomeActiveWorkItem)
+                            }
         }
     }
 

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -57,6 +57,9 @@ public final class Siren: NSObject {
 
     /// The completion handler used to return the results or errors returned by Siren.
     private var resultsHandler: ResultsHandler?
+    
+    /// Prevent can't appear update dialog when user swipe down the notification center screen to the bottom of screen when call Siren.shared.wail as .onForeground
+    private var appDidBecomeActiveWorkItem: DispatchWorkItem?
 
     /// The deinitialization method that clears out all observers,
     deinit {
@@ -282,7 +285,10 @@ private extension Siren {
                          object: nil,
                          queue: nil) { [weak self] _ in
                             guard let self = self else { return }
-                            self.startVersionCheckFlow()
+                            self.appDidBecomeActiveWorkItem = DispatchWorkItem {
+                                self.performVersionCheck()
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02, execute: self.appDidBecomeActiveWorkItem!)
         }
     }
 
@@ -296,6 +302,8 @@ private extension Siren {
                              object: nil,
                              queue: nil) { [weak self] _ in
                                 guard let self = self else { return }
+                                self.appDidBecomeActiveWorkItem?.cancel()
+                                self.appDidBecomeActiveWorkItem = nil
                                 self.presentationManager.cleanUp()
             }
         }


### PR DESCRIPTION
**Problem**
1. Check update as .onForeground (Siren.shared.wail(performCheck: .onForeground))
2. If user swipe down the notification center screen to the bottom of screen (by swiping downward from the very top of the device's screen)
3. And back to app can't appear update dialog



**Reason**

If swipe down the notification center screen to the bottom of screen
iOS call observer like this
1. starting to swipe down : willResignActiveNotification
2. reached to bottom : didBecomeActiveNotification, willResignActiveNotification