### PR TITLE
Add async version of `wail` and functionality to skip version from outside of the package

### DIFF
--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -100,15 +100,24 @@ public extension Siren {
         addBackgroundObservers()
     }
 
-    /// This method executes the Siren version checking and alert presentation flow.
+    /// This method executes the Siren version checking and alert presentation flow only once.
     ///
-    /// - Parameters:
-    ///   - performCheck: Defines how the version check flow is entered. Defaults to `.onForeground`.
     /// - Returns: the metadata around a successful version check and interaction with the update modal.
-    func wail(performCheck: PerformCheck = .onForeground) async throws -> UpdateResults {
+    func wailOnce() async throws -> UpdateResults {
         try await withCheckedThrowingContinuation { continuation in
-            wail(performCheck: performCheck) { result in
+            wail(performCheck: .onDemand) { result in
                 continuation.resume(with: result)
+            }
+        }
+    }
+  
+    /// This method executes the Siren version checking and alert presentation flow when app goes to foreground.
+    ///
+    /// - Returns: the metadata around a successful version check and interaction with the update modal.
+    func wailWhenOnForeground() throws -> AsyncStream<Result<UpdateResults, KnownError>> {
+        AsyncStream { continuation in
+            wail(performCheck: .onForeground) { result in
+                continuation.yield(result)
             }
         }
     }

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -128,6 +128,15 @@ public extension Siren {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
     }
+
+    /// Marks the version as skipped to avoid showing and update alert for this version from now.
+    ///
+    /// This function is marked `public` as a convenience for those developers who decide to build a custom alert modal
+    /// instead of using Siren's prebuilt update alert.
+    func skipVersion(_ version: String) {
+        UserDefaults.storedSkippedVersion = version
+        UserDefaults.standard.synchronize()
+    }
 }
 
 // MARK: - Version Check and Alert Presentation Flow
@@ -287,8 +296,7 @@ private extension Siren {
             launchAppStore()
         case .skip:
             guard let currentAppStoreVersion = currentAppStoreVersion else { return }
-            UserDefaults.storedSkippedVersion = currentAppStoreVersion
-            UserDefaults.standard.synchronize()
+            skipVersion(currentAppStoreVersion)
         default:
             break
         }

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -160,7 +160,7 @@ private extension Siren {
         } catch (let error as KnownError) {
             self.resultsHandler?(.failure(error))
         } catch {
-            // Do nothing. Silences exhaustive error.
+            self.resultsHandler?(.failure(.appStoreDataRetrievalFailure(underlyingError: error)))
         }
     }
 

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -107,7 +107,7 @@ public extension Siren {
     /// - Returns: the metadata around a successful version check and interaction with the update modal.
     func wail(performCheck: PerformCheck = .onForeground) async throws -> UpdateResults {
         try await withCheckedThrowingContinuation { continuation in
-            wail { result in
+            wail(performCheck: performCheck) { result in
                 continuation.resume(with: result)
             }
         }

--- a/Sources/Siren.swift
+++ b/Sources/Siren.swift
@@ -100,6 +100,19 @@ public extension Siren {
         addBackgroundObservers()
     }
 
+    /// This method executes the Siren version checking and alert presentation flow.
+    ///
+    /// - Parameters:
+    ///   - performCheck: Defines how the version check flow is entered. Defaults to `.onForeground`.
+    /// - Returns: the metadata around a successful version check and interaction with the update modal.
+    func wail(performCheck: PerformCheck = .onForeground) async throws -> UpdateResults {
+        try await withCheckedThrowingContinuation { continuation in
+            wail { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
     /// Launches the AppStore in two situations when the user clicked the `Update` button in the UIAlertController modal.
     ///
     /// This function is marked `public` as a convenience for those developers who decide to build a custom alert modal


### PR DESCRIPTION
Made a `skipVersion` public method to allow developers skip the current version when using custom alert. 